### PR TITLE
DoubleApiKey Implementation

### DIFF
--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -23,7 +23,7 @@ impl fmt::Debug for AuthMode {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AuthMode::ApiKey(_) => write!(formatter, "API key"),
-            AuthMode::DoubleApiKey { read: _, write: _ } => write!(formatter, "double API key"),
+            AuthMode::DoubleApiKey { .. } => write!(formatter, "double API key"),
             AuthMode::Unauthenticated => write!(formatter, "no authentication"),
         }
     }
@@ -64,7 +64,7 @@ impl<'r> FromRequest<'r> for ReadAccess {
         match &config.auth {
             AuthMode::Unauthenticated => Outcome::Success(Self { _dummy: 0 }),
             AuthMode::ApiKey(key) => match_api_key(request, key, Self { _dummy: 0 }),
-            AuthMode::DoubleApiKey { read, write: _ } => match read {
+            AuthMode::DoubleApiKey { read, .. } => match read {
                 None => Outcome::Success(Self { _dummy: 0 }),
                 Some(key) => match_api_key(request, key, Self { _dummy: 0 }),
             },
@@ -92,7 +92,7 @@ impl<'r> FromRequest<'r> for WriteAccess {
                 format_err!("Invalid API key for write access"),
             )),
             AuthMode::ApiKey(key) => match_api_key(request, key, Self { _dummy: 0 }),
-            AuthMode::DoubleApiKey { read: _, write } => {
+            AuthMode::DoubleApiKey { write, .. } => {
                 match_api_key(request, write, Self { _dummy: 0 })
             }
         }

--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -15,6 +15,7 @@ use crate::config::Config;
 #[serde(tag = "type", content = "value", rename_all = "kebab-case")]
 pub enum AuthMode {
     ApiKey(String),
+    DoubleApiKey { read: Option<String>, write: String },
     Unauthenticated,
 }
 
@@ -22,6 +23,7 @@ impl fmt::Debug for AuthMode {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AuthMode::ApiKey(_) => write!(formatter, "API key"),
+            AuthMode::DoubleApiKey { read: _, write: _ } => write!(formatter, "Double API key"),
             AuthMode::Unauthenticated => write!(formatter, "no authentication"),
         }
     }
@@ -62,6 +64,10 @@ impl<'r> FromRequest<'r> for ReadAccess {
         match &config.auth {
             AuthMode::Unauthenticated => Outcome::Success(Self { _dummy: 0 }),
             AuthMode::ApiKey(key) => match_api_key(request, key, Self { _dummy: 0 }),
+            AuthMode::DoubleApiKey { read, write: _ } => match read {
+                None => Outcome::Success(Self { _dummy: 0 }),
+                Some(key) => match_api_key(request, key, Self { _dummy: 0 }),
+            },
         }
     }
 }
@@ -86,6 +92,9 @@ impl<'r> FromRequest<'r> for WriteAccess {
                 format_err!("Invalid API key for write access"),
             )),
             AuthMode::ApiKey(key) => match_api_key(request, key, Self { _dummy: 0 }),
+            AuthMode::DoubleApiKey { read: _, write } => {
+                match_api_key(request, write, Self { _dummy: 0 })
+            }
         }
     }
 }

--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -23,7 +23,7 @@ impl fmt::Debug for AuthMode {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
             AuthMode::ApiKey(_) => write!(formatter, "API key"),
-            AuthMode::DoubleApiKey { read: _, write: _ } => write!(formatter, "Double API key"),
+            AuthMode::DoubleApiKey { read: _, write: _ } => write!(formatter, "double API key"),
             AuthMode::Unauthenticated => write!(formatter, "no authentication"),
         }
     }

--- a/wally-registry-backend/src/tests/mod.rs
+++ b/wally-registry-backend/src/tests/mod.rs
@@ -195,21 +195,27 @@ fn read_write_double_key() {
     .assert(response);
 
     // But we can't write with no API key
-    let response = client.post("/v1/publish").header(Accept::JSON).dispatch();
+    let contents = PackageBuilder::new("biff/hello@1.0.0").contents();
+    let response = client
+        .post("/v1/publish")
+        .header(Accept::JSON)
+        .body(contents.data())
+        .dispatch();
+
     Expectation {
         status: Status::Unauthorized,
         content_type: ContentType::JSON,
     }
     .assert(response);
 
-    // Unless it's the correct API key
-    let contents = PackageBuilder::new("biff/hello@1.0.0").contents();
+    // Unless we use the correct API key
     let response = client
         .post("/v1/publish")
         .header(Accept::JSON)
         .body(contents.data())
         .header(Header::new("Authorization", "Bearer A write key"))
         .dispatch();
+
     Expectation {
         status: Status::Ok,
         content_type: ContentType::JSON,


### PR DESCRIPTION
Currently a user either has to have the api key to read, or they can read unauthenticated but it's tricky to publish. This PR adds a new AuthMode which allows read/write access to be split between two separate api keys. The read api key is optional. 

The usual use case for this is allowing public read access but restricting write access so I've also added a test which emulates this use case.