### PR TITLE
Fix sibling link path

### DIFF
--- a/src/installation.rs
+++ b/src/installation.rs
@@ -115,7 +115,7 @@ impl InstallationContext {
     /// Contents of a package-to-package link within the same index.
     fn link_sibling_same_index(&self, id: &PackageId) -> String {
         formatdoc! {r#"
-            return require(script.Parent.Parent._Index["{full_name}"]["{short_name}"])
+            return require(script.Parent.Parent["{full_name}"]["{short_name}"])
             "#,
             full_name = package_id_file_name(id),
             short_name = id.name().name()

--- a/tests/integration/snapshots/integration__install__transitive_dependency.snap
+++ b/tests/integration/snapshots/integration__install__transitive_dependency.snap
@@ -10,7 +10,7 @@ ServerPackages:
       minimal:
         init.lua: "return \"hey\""
     biff_one-dependency@0.1.0:
-      Minimal.lua: "return require(script.Parent.Parent._Index[\"biff_minimal@0.1.0\"][\"minimal\"])\n"
+      Minimal.lua: "return require(script.Parent.Parent[\"biff_minimal@0.1.0\"][\"minimal\"])\n"
       one-dependency:
         init.lua: "return \"hey\""
 default.project.json: "{\n\t\"name\": \"transitive-dependency\",\n\t\"tree\": {\n\t\t\"$path\": \"src\"\n\t}\n}"


### PR DESCRIPTION
This fixes #16 by updating the relative path created for linking sibling dependencies.