### PR TITLE
Fix init generating invalid package names

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -61,7 +61,7 @@ impl InitSubcommand {
             .parse::<Document>()
             .expect("Built-in default manifest was invalid TOML");
 
-        let full_name = format!("{}/{}", whoami::username(), package_name);
+        let full_name = format!("{}/{}", whoami::username(), package_name).to_lowercase();
         doc["package"]["name"] = value(full_name.clone());
 
         fs_err::write(manifest_path, doc.to_string())?;


### PR DESCRIPTION
This fixes #12 by converting the full package name to all lowercase letters.