### PR TITLE
Public Authentication Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2542,6 +2542,7 @@ dependencies = [
  "futures",
  "git2",
  "glob",
+ "reqwest",
  "rocket",
  "rocket_contrib",
  "semver 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
+name = "opener"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
+dependencies = [
+ "bstr",
+ "winapi",
+]
+
+[[package]]
 name = "openssl"
 version = "0.10.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1544,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -2514,6 +2541,7 @@ dependencies = [
  "insta",
  "log",
  "once_cell",
+ "opener",
  "reqwest",
  "rpassword",
  "semver 0.11.0",
@@ -2525,7 +2553,6 @@ dependencies = [
  "toml_edit",
  "url",
  "walkdir",
- "webbrowser",
  "whoami",
  "zip",
 ]
@@ -2657,17 +2684,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webbrowser"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a"
-dependencies = [
- "web-sys",
- "widestring",
- "winapi",
-]
-
-[[package]]
 name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,12 +2711,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,6 +2525,7 @@ dependencies = [
  "toml_edit",
  "url",
  "walkdir",
+ "webbrowser",
  "whoami",
  "zip",
 ]
@@ -2656,6 +2657,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a"
+dependencies = [
+ "web-sys",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
 name = "webpki"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2683,6 +2695,12 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ toml = "0.5.6"
 toml_edit = "0.2.0"
 url = { version = "2.1.1", features = ["serde"] }
 walkdir = "2.3.1"
+webbrowser = "0.5.5"
 whoami = "1.1.2"
 zip = "0.5.11"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ hex = "0.4.2"
 indoc = "1.0.3"
 log = "0.4.11"
 once_cell = "1.5.2"
+opener = "0.5.0"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 rpassword = "5.0.1"
 semver = { version = "0.11.0", features = ["serde"] }
@@ -49,7 +50,6 @@ toml = "0.5.6"
 toml_edit = "0.2.0"
 url = { version = "2.1.1", features = ["serde"] }
 walkdir = "2.3.1"
-webbrowser = "0.5.5"
 whoami = "1.1.2"
 zip = "0.5.11"
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -39,13 +39,14 @@ impl AuthStore {
         let contents = Self::contents(&path)?;
 
         let mut auth: Document = contents.parse().unwrap();
-        let key = format!("\"{}\"", key);
+        let key = format!("\"{}\"", key); // toml_edit won't automatically put our key in quotes
 
-        if let Some(token) = token {
-            auth["tokens"][key] = value(token);
-        } else {
-            if let Some(tokens) = auth["tokens"].as_table_mut() {
-                tokens.remove(&key);
+        if let Some(tokens) = auth["tokens"].as_table_mut() {
+            // We need to remove the key before writing, toml_edit will write duplicate keys
+            tokens.remove(&key);
+
+            if let Some(token) = token {
+                auth["tokens"][key] = value(token);
             }
         }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -12,6 +12,9 @@ use toml_edit::{table, value, Document, Item};
 const DEFAULT_AUTH_TOML: &str = r#"
 # This is where Wally stores details for authenticating with registries.
 # It can be updated using `wally login` and `wally logout`.
+
+[tokens]
+
 "#;
 
 #[derive(Serialize, Deserialize)]

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,9 +1,9 @@
 use anyhow::format_err;
+use opener;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::{thread, time};
 use structopt::StructOpt;
-use webbrowser;
 
 use crate::{auth::AuthStore, manifest::Manifest, package_index::PackageIndex};
 
@@ -91,7 +91,7 @@ fn prompt_github_auth(api: url::Url, oauth_id: &str) -> anyhow::Result<()> {
     println!("And enter the code: {}", device_code_response.user_code);
     println!();
 
-    webbrowser::open(&device_code_response.verification_uri).ok();
+    opener::open(&device_code_response.verification_uri).ok();
 
     println!("Awaiting authorization...");
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 use std::{thread, time};
 use structopt::StructOpt;
+use webbrowser;
 
 use crate::{auth::AuthStore, manifest::Manifest, package_index::PackageIndex};
 
@@ -85,10 +86,10 @@ fn prompt_github_auth(api: url::Url, oauth_id: &str) -> anyhow::Result<()> {
         .send()?
         .json::<DeviceCodeResponse>()?;
 
-    println!(
-        "Go to {} and enter the code {}",
-        device_code_response.verification_uri, device_code_response.user_code
-    );
+    println!("Go to {}", device_code_response.verification_uri);
+    println!("And enter the code: {}", device_code_response.user_code);
+
+    webbrowser::open(&device_code_response.verification_uri).ok();
 
     println!("Awaiting authorization...");
 

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,3 +1,6 @@
+use anyhow::format_err;
+use serde::Deserialize;
+use std::{thread, time};
 use structopt::StructOpt;
 
 use crate::auth::AuthStore;
@@ -10,9 +13,57 @@ pub struct LoginSubcommand {
     pub token: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u64,
+    interval: u64,
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeAuth {
+    access_token: String,
+    token_type: String,
+    scope: String,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum AuthResponse {
+    Ok(DeviceCodeAuth),
+    Err { error: String },
+}
+
+fn await_github_auth(device_code_response: DeviceCodeResponse) -> anyhow::Result<DeviceCodeAuth> {
+    let client = reqwest::blocking::Client::new();
+
+    thread::sleep(time::Duration::from_secs(device_code_response.interval));
+
+    let response = client
+        .post("https://github.com/login/oauth/access_token")
+        .header("accept", "application/json")
+        .json(&serde_json::json!({
+            "client_id": "7bd503594a0f9a9f7ed3",
+            "device_code": device_code_response.device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }))
+        .send()?
+        .json::<AuthResponse>()?;
+
+    match response {
+        AuthResponse::Ok(auth) => Ok(auth),
+        AuthResponse::Err { error } => match error.as_ref() {
+            "authorization_pending" => await_github_auth(device_code_response),
+            _ => Err(format_err!("Oauth request error: {}", error)),
+        },
+    }
+}
+
 impl LoginSubcommand {
     pub fn run(self) -> anyhow::Result<()> {
-        let token = match self.token {
+        /*let token = match self.token {
             Some(token) => token,
             None => {
                 println!("Wally currently authenticates to registries with an API token.");
@@ -22,8 +73,33 @@ impl LoginSubcommand {
             }
         };
 
-        AuthStore::set_token(Some(&token))?;
+        AuthStore::set_token(Some(&token))?;*/
 
-        Ok(())
+        let client = reqwest::blocking::Client::new();
+        let device_code_response = client
+            .post("https://github.com/login/device/code")
+            .header("accept", "application/json")
+            .json(&serde_json::json!({
+                "client_id": "7bd503594a0f9a9f7ed3",
+                "scope": "read:user",
+            }))
+            .send()?
+            .json::<DeviceCodeResponse>()?;
+
+        println!(
+            "Go to {} and enter the code {}",
+            device_code_response.verification_uri, device_code_response.user_code
+        );
+
+        println!("Awaiting authorization...");
+
+        match await_github_auth(device_code_response) {
+            Ok(auth) => {
+                println!("Authorization successful!");
+                AuthStore::set_token(Some(&auth.access_token))?;
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     }
 }

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -86,6 +86,7 @@ fn prompt_github_auth(api: url::Url, oauth_id: &str) -> anyhow::Result<()> {
         .send()?
         .json::<DeviceCodeResponse>()?;
 
+    println!();
     println!("Go to {}", device_code_response.verification_uri);
     println!("And enter the code: {}", device_code_response.user_code);
     println!();

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -1,16 +1,17 @@
 use anyhow::format_err;
 use serde::Deserialize;
+use std::path::PathBuf;
 use std::{thread, time};
 use structopt::StructOpt;
 
-use crate::auth::AuthStore;
+use crate::{auth::AuthStore, manifest::Manifest, package_index::PackageIndex};
 
 /// Log into a registry.
 #[derive(Debug, StructOpt)]
 pub struct LoginSubcommand {
-    /// Authentication token for the registry. If not specified, Wally will
-    /// prompt.
-    pub token: Option<String>,
+    /// Path to a project to decide how to login
+    #[structopt(long = "project-path", default_value = ".")]
+    pub project_path: PathBuf,
 }
 
 #[derive(Debug, Deserialize)]
@@ -36,7 +37,10 @@ enum AuthResponse {
     Err { error: String },
 }
 
-fn await_github_auth(device_code_response: DeviceCodeResponse) -> anyhow::Result<DeviceCodeAuth> {
+fn await_github_auth(
+    device_code_response: DeviceCodeResponse,
+    oauth_id: &str,
+) -> anyhow::Result<DeviceCodeAuth> {
     let client = reqwest::blocking::Client::new();
 
     thread::sleep(time::Duration::from_secs(device_code_response.interval));
@@ -45,7 +49,7 @@ fn await_github_auth(device_code_response: DeviceCodeResponse) -> anyhow::Result
         .post("https://github.com/login/oauth/access_token")
         .header("accept", "application/json")
         .json(&serde_json::json!({
-            "client_id": "7bd503594a0f9a9f7ed3",
+            "client_id": oauth_id,
             "device_code": device_code_response.device_code,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
         }))
@@ -55,51 +59,60 @@ fn await_github_auth(device_code_response: DeviceCodeResponse) -> anyhow::Result
     match response {
         AuthResponse::Ok(auth) => Ok(auth),
         AuthResponse::Err { error } => match error.as_ref() {
-            "authorization_pending" => await_github_auth(device_code_response),
+            "authorization_pending" => await_github_auth(device_code_response, oauth_id),
             _ => Err(format_err!("Oauth request error: {}", error)),
         },
     }
 }
 
+fn prompt_api_key(api: url::Url) -> anyhow::Result<()> {
+    println!("Enter an API token for {}", api);
+    println!();
+    let token = rpassword::prompt_password_stdout("Enter token: ")?;
+
+    AuthStore::set_token(api.as_str(), Some(&token))
+}
+
+fn prompt_github_auth(api: url::Url, oauth_id: &str) -> anyhow::Result<()> {
+    let client = reqwest::blocking::Client::new();
+    let device_code_response = client
+        .post("https://github.com/login/device/code")
+        .header("accept", "application/json")
+        .json(&serde_json::json!({
+            "client_id": oauth_id,
+            "scope": "read:user",
+        }))
+        .send()?
+        .json::<DeviceCodeResponse>()?;
+
+    println!(
+        "Go to {} and enter the code {}",
+        device_code_response.verification_uri, device_code_response.user_code
+    );
+
+    println!("Awaiting authorization...");
+
+    match await_github_auth(device_code_response, oauth_id) {
+        Ok(auth) => {
+            println!("Authorization successful!");
+            AuthStore::set_token(api.as_str(), Some(&auth.access_token))?;
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
 impl LoginSubcommand {
     pub fn run(self) -> anyhow::Result<()> {
-        /*let token = match self.token {
-            Some(token) => token,
-            None => {
-                println!("Wally currently authenticates to registries with an API token.");
-                println!("In the future, Wally will support GitHub authentication.");
-                println!();
-                rpassword::prompt_password_stdout("Enter token: ")?
-            }
-        };
+        let manifest = Manifest::load(&self.project_path)?;
+        let registry = url::Url::parse(&manifest.package.registry)?;
+        let package_index = PackageIndex::new(&registry, None)?;
+        let api = package_index.config()?.api;
+        let oauth_id = package_index.config()?.oauth_id;
 
-        AuthStore::set_token(Some(&token))?;*/
-
-        let client = reqwest::blocking::Client::new();
-        let device_code_response = client
-            .post("https://github.com/login/device/code")
-            .header("accept", "application/json")
-            .json(&serde_json::json!({
-                "client_id": "7bd503594a0f9a9f7ed3",
-                "scope": "read:user",
-            }))
-            .send()?
-            .json::<DeviceCodeResponse>()?;
-
-        println!(
-            "Go to {} and enter the code {}",
-            device_code_response.verification_uri, device_code_response.user_code
-        );
-
-        println!("Awaiting authorization...");
-
-        match await_github_auth(device_code_response) {
-            Ok(auth) => {
-                println!("Authorization successful!");
-                AuthStore::set_token(Some(&auth.access_token))?;
-                Ok(())
-            }
-            Err(error) => Err(error),
+        match oauth_id {
+            None => prompt_api_key(api),
+            Some(oauth_id) => prompt_github_auth(api, &oauth_id),
         }
     }
 }

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,14 +1,24 @@
+use std::path::PathBuf;
 use structopt::StructOpt;
 
-use crate::auth::AuthStore;
+use crate::{auth::AuthStore, manifest::Manifest, package_index::PackageIndex};
 
 /// Log out of a registry.
 #[derive(Debug, StructOpt)]
-pub struct LogoutSubcommand {}
+pub struct LogoutSubcommand {
+    /// Path to a project to decide how to logout
+    #[structopt(long = "project-path", default_value = ".")]
+    pub project_path: PathBuf,
+}
 
 impl LogoutSubcommand {
     pub fn run(self) -> anyhow::Result<()> {
-        AuthStore::set_token(None)?;
+        let manifest = Manifest::load(&self.project_path)?;
+        let registry = url::Url::parse(&manifest.package.registry)?;
+        let package_index = PackageIndex::new(&registry, None)?;
+        let api = package_index.config()?.api;
+
+        AuthStore::set_token(api.as_str(), None)?;
 
         Ok(())
     }

--- a/src/commands/logout.rs
+++ b/src/commands/logout.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+
 use structopt::StructOpt;
 
 use crate::{auth::AuthStore, manifest::Manifest, package_index::PackageIndex};

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -26,8 +26,9 @@ impl PublishSubcommand {
         let contents = PackageContents::pack_from_path(&self.project_path)?;
 
         let auth = auth_store
-            .token
-            .with_context(|| "Auth token is required to publish, use `wally login`")?;
+            .tokens
+            .get(api.as_str())
+            .with_context(|| "Authentication is required to publish, use `wally login`")?;
 
         println!(
             "Publishing {} to {}",

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -39,6 +39,7 @@ impl PublishSubcommand {
         let client = reqwest::blocking::Client::new();
         let response = client
             .post(api.join("/v1/publish")?)
+            .header("accept", "application/json")
             .bearer_auth(auth)
             .body(contents.data().to_owned())
             .send()?;

--- a/src/package_index.rs
+++ b/src/package_index.rs
@@ -18,6 +18,7 @@ use crate::package_name::PackageName;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PackageIndexConfig {
     pub api: Url,
+    pub oauth_id: Option<String>,
 }
 
 pub struct PackageIndex {

--- a/src/package_index.rs
+++ b/src/package_index.rs
@@ -218,8 +218,8 @@ impl PackageIndex {
         path.push("owners.json");
 
         {
-            let mut file = OpenOptions::new().write(true).create(true).open(&path)?;
             let mut owners = self.get_scope_owners(&scope)?;
+            let mut file = OpenOptions::new().write(true).create(true).open(&path)?;
 
             owners.push(*owner_id);
             file.write_all(serde_json::to_string(&owners)?.as_bytes())?;

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -36,8 +36,11 @@ impl Registry {
         self.auth_token
             .get_or_try_init(|| {
                 let store = AuthStore::load()?;
-                let token = store.token.map(Arc::from);
-                Ok(token)
+                let token = store.tokens.get(self.api_url()?.as_str());
+                match token {
+                    Some(token) => Ok(Some(Arc::from(token.as_str()))),
+                    None => Ok(None),
+                }
             })
             .map(|token| token.clone())
     }

--- a/wally-registry-backend/Cargo.toml
+++ b/wally-registry-backend/Cargo.toml
@@ -20,6 +20,7 @@ figment = "0.10.3"
 fs-err = "2.5.0"
 futures = "0.3.13"
 git2 = "0.13.17"
+reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 rocket = { git = "https://github.com/SergioBenitez/Rocket", rev = "2893ce754d6535e0a752586e60d7e292343016c0" }
 rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", rev = "2893ce754d6535e0a752586e60d7e292343016c0" }
 semver = "0.11.0"

--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use anyhow::{format_err, Context};
+use anyhow::format_err;
 use constant_time_eq::constant_time_eq;
 use libwally::{package_id::PackageId, package_index::PackageIndex};
 use reqwest::Client;
@@ -101,7 +101,7 @@ async fn verify_github_token(request: &Request<'_>) -> Outcome<WriteAccess, anyh
 }
 
 pub enum ReadAccess {
-    Global,
+    Public,
     ApiKey,
 }
 
@@ -116,11 +116,11 @@ impl<'r> FromRequest<'r> for ReadAccess {
             .expect("AuthMode was not configured");
 
         match &config.auth {
-            AuthMode::Unauthenticated => Outcome::Success(ReadAccess::Global),
-            AuthMode::GithubOAuth => Outcome::Success(ReadAccess::Global),
+            AuthMode::Unauthenticated => Outcome::Success(ReadAccess::Public),
+            AuthMode::GithubOAuth => Outcome::Success(ReadAccess::Public),
             AuthMode::ApiKey(key) => match_api_key(request, key, ReadAccess::ApiKey),
             AuthMode::DoubleApiKey { read, .. } => match read {
-                None => Outcome::Success(ReadAccess::Global),
+                None => Outcome::Success(ReadAccess::Public),
                 Some(key) => match_api_key(request, key, ReadAccess::ApiKey),
             },
         }

--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -144,7 +144,7 @@ impl WriteAccess {
 
                 match is_owner {
                     true => Ok(()),
-                    false if github_info.login() == scope => {
+                    false if github_info.login().to_lowercase() == scope => {
                         index
                             .add_scope_owner(scope, github_info.id())
                             .context(format!("Could not add owner to scope {}", scope))?;

--- a/wally-registry-backend/src/main.rs
+++ b/wally-registry-backend/src/main.rs
@@ -98,27 +98,7 @@ async fn publish(
     let manifest = get_manifest(&mut archive).status(Status::BadRequest)?;
     let package_id = manifest.package_id();
 
-    let scope = package_id.name().scope();
-    let package_owners = index.get_scope_owners(&scope)?;
-
-    let has_authorization = match authorization.github() {
-        None => Ok(()), // We authenticated using another method
-        Some(github_info) => match package_owners {
-            None if github_info.login() == scope => {
-                index
-                    .add_scope_owner(scope, github_info.id())
-                    .context("Could not add owner to scope")?;
-                Ok(())
-            }
-            None => Err("you cannot claim this scope"),
-            Some(owners) => match owners.iter().any(|owner| owner == github_info.id()) {
-                true => Ok(()),
-                false => Err("you do not own this scope"),
-            },
-        },
-    };
-
-    if let Err(message) = has_authorization {
+    if let Err(message) = authorization.can_write_package(&package_id, &index) {
         return Err(format_err!(message).status(Status::Unauthorized));
     }
 


### PR DESCRIPTION
This PR is the implementation of public authentication! It closes issue https://github.com/UpliftGames/wally/issues/8, see that for more info.

This PR:
- Adds support for associating an oauth client id with a registry
- Allows `wally login` to ask for an api key or present an oauth flow if the registry has an oauth client id
- Allows storage of authentication tokens on a per registry basis
- Enables the registry backend to accept oauth tokens as authentication by verifying them against the github api
- Creates `owners.json` files in scopes to track ownership and enable ownership by multiple users (although no command to do so exists yet)