### PR TITLE
Readable package name parsing errors

### DIFF
--- a/src/package_name.rs
+++ b/src/package_name.rs
@@ -53,7 +53,7 @@ fn validate_scope(scope: &str) -> anyhow::Result<()> {
 
     ensure!(
         only_valid_chars,
-        "package scope {} in invalid (scopes can only contain lowercase characters, digits and '-')",
+        "package scope '{}' is invalid (scopes can only contain lowercase characters, digits and '-')",
         scope
     );
     ensure!(scope.len() > 0, "package scopes cannot be empty");
@@ -68,7 +68,7 @@ fn validate_name(name: &str) -> anyhow::Result<()> {
 
     ensure!(
         only_valid_chars,
-        "package name {} in invalid (names can only contain lowercase characters, digits and '-')",
+        "package name '{}' is invalid (names can only contain lowercase characters, digits and '-')",
         name
     );
     ensure!(name.len() > 0, "package names cannot be empty");

--- a/src/package_name.rs
+++ b/src/package_name.rs
@@ -31,16 +31,8 @@ impl PackageName {
         let scope = scope.into();
         let name = name.into();
 
-        ensure!(
-            is_ident_valid(&scope),
-            "package scope '{}' is not valid",
-            scope
-        );
-        ensure!(
-            is_ident_valid(&name),
-            "package name '{}' is not valid",
-            name
-        );
+        validate_scope(&scope)?;
+        validate_name(&name)?;
 
         Ok(PackageName { scope, name })
     }
@@ -54,14 +46,32 @@ impl PackageName {
     }
 }
 
-fn is_ident_valid(ident: &str) -> bool {
-    let only_valid_chars = ident
+fn validate_scope(scope: &str) -> anyhow::Result<()> {
+    let only_valid_chars = scope
         .chars()
         .all(|char| char.is_ascii_lowercase() || char.is_ascii_digit() || char == '-');
 
-    let valid_length = ident.len() > 0;
+    ensure!(
+        only_valid_chars,
+        format!("package scope {} in invalid (scopes can only contain lowercase characters, digits and '-')", scope)
+    );
+    ensure!(scope.len() > 0, "package scopes cannot be empty");
 
-    only_valid_chars && valid_length
+    Ok(())
+}
+
+fn validate_name(name: &str) -> anyhow::Result<()> {
+    let only_valid_chars = name
+        .chars()
+        .all(|char| char.is_ascii_lowercase() || char.is_ascii_digit() || char == '-');
+
+    ensure!(
+        only_valid_chars,
+        format!("package name {} in invalid (names can only contain lowercase characters, digits and '-')", name)
+    );
+    ensure!(name.len() > 0, "package names cannot be empty");
+
+    Ok(())
 }
 
 impl fmt::Display for PackageName {

--- a/src/package_name.rs
+++ b/src/package_name.rs
@@ -53,7 +53,8 @@ fn validate_scope(scope: &str) -> anyhow::Result<()> {
 
     ensure!(
         only_valid_chars,
-        format!("package scope {} in invalid (scopes can only contain lowercase characters, digits and '-')", scope)
+        "package scope {} in invalid (scopes can only contain lowercase characters, digits and '-')",
+        scope
     );
     ensure!(scope.len() > 0, "package scopes cannot be empty");
 
@@ -67,7 +68,8 @@ fn validate_name(name: &str) -> anyhow::Result<()> {
 
     ensure!(
         only_valid_chars,
-        format!("package name {} in invalid (names can only contain lowercase characters, digits and '-')", name)
+        "package name {} in invalid (names can only contain lowercase characters, digits and '-')",
+        name
     );
     ensure!(name.len() > 0, "package names cannot be empty");
 


### PR DESCRIPTION
Errors during parsing of package names is confusing, see #13. This PR adds extra info to the errors output so users can understand what went wrong more easily.

Users will now see this when they have an invalid scope
```
failed to parse manifest at path /../../wally.toml

Caused by:
    package scope Magnalite in invalid (scopes can only contain lowercase characters, digits and '-') for key `package.name` at line 2 column 8
```

I'm not very happy with this but I'm not sure how else to do it. Ideally we would output multiple layers of anyhow context but this isn't easy to do as the toml parsing is what consumes the anyhow error. 