### PR TITLE
Reuse Client in Registry when downloading packages

### DIFF
--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -17,6 +17,7 @@ pub struct Registry {
     index_url: Url,
     auth_token: OnceCell<Option<Arc<str>>>,
     index: OnceCell<PackageIndex>,
+    client: Client,
 }
 
 impl Registry {
@@ -29,6 +30,7 @@ impl Registry {
             index_url,
             auth_token: OnceCell::new(),
             index: OnceCell::new(),
+            client: Client::new(),
         })
     }
 
@@ -84,9 +86,7 @@ impl PackageSource for Registry {
 
         let url = self.api_url()?.join(&path)?;
 
-        let client = Client::new();
-
-        let mut request = client.get(url);
+        let mut request = self.client.get(url);
 
         if let Some(token) = self.auth_token()? {
             request = request.header(AUTHORIZATION, format!("Bearer {}", token));


### PR DESCRIPTION
Store the Client in the struct rather than creating a new one per package download.
This is suggested by the [reqwest docs](https://docs.rs/reqwest/0.11.4/reqwest/blocking/fn.get.html) for when multiple http requests are being made.