### PR TITLE
Ensure max length for package name

### DIFF
--- a/src/package_name.rs
+++ b/src/package_name.rs
@@ -57,6 +57,10 @@ fn validate_scope(scope: &str) -> anyhow::Result<()> {
         scope
     );
     ensure!(scope.len() > 0, "package scopes cannot be empty");
+    ensure!(
+        scope.len() <= 64,
+        "package scopes cannot exceed 64 characters in length"
+    );
 
     Ok(())
 }
@@ -72,6 +76,10 @@ fn validate_name(name: &str) -> anyhow::Result<()> {
         name
     );
     ensure!(name.len() > 0, "package names cannot be empty");
+    ensure!(
+        name.len() <= 64,
+        "package names cannot exceed 64 characters in length"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Currently we set no limit for package names. This PR ensures that packages names don't contain more than 64 characters. This is the same limit crates.io uses and seems reasonable for our use case too. I also added a check for package scope length. Although checking scope length shouldn't be necessary I didn't see much reason to not include it either.