### PR TITLE
Fix windows generating invalid zip archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased Changes
 
+* Fixed Windows generating invalid zip archives. ([#15][15])
+
+[#15]: https://github.com/UpliftGames/wally/issues/15
+
 ## 0.2.1 (2021-10-01)
 * First iteration of wally frontend. ([#32][#32])
 

--- a/src/package_contents.rs
+++ b/src/package_contents.rs
@@ -43,6 +43,11 @@ impl PackageContents {
                 )
             })?;
 
+            // Zips embed \ from windows paths causing incorrect extraction on unix operating
+            // systems; we must sanitise here. See: https://github.com/UpliftGames/wally/issues/15
+            // This may be fixed in the zip crate. See: https://github.com/zip-rs/zip/issues/253
+            let archive_name = str::replace(archive_name, "\\", "/");
+
             if entry.file_type().is_dir() {
                 archive.add_directory(archive_name, FileOptions::default())?;
             } else {


### PR DESCRIPTION
Windows paths are not sanitised before being included in the package zip archives #15. This causes them to be incorrectly extracted when used in a unix environment. This PR changes `\`s to `/`s in these paths so the zip archives remain compatible across both Windows and unix environments.

This fix is somewhat naive and may be susceptible to edge cases. However I don't believe they are edge cases we are likely to run into as we only use relative paths. This also seems to be a known issue in the zip crate as it was accounted for once before but has since, seemingly accidentally, been left out. You can see that issue here https://github.com/zip-rs/zip/issues/253. Hopefully that means this will be addressed in the crate soon so we can then remove our fix.