### PR TITLE
Generate server->shared cross realm links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 # Wally Changelog
 
 ## Unreleased Changes
+
+* Fixed Windows generating invalid zip archives. ([#15][#15])
 * Support for registry fallback chains ([#35][#35])
-
-[#35]: https://github.com/UpliftGames/wally/pull/35
-
-* Fixed Windows generating invalid zip archives. ([#15][15])
+* Generate cross realm package links ([#38][#38])
 
 [#15]: https://github.com/UpliftGames/wally/issues/15
-
+[#35]: https://github.com/UpliftGames/wally/pull/35
+[#38]: https://github.com/UpliftGames/wally/pull/38
 ## 0.2.1 (2021-10-01)
 * First iteration of wally frontend. ([#32][#32])
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -57,9 +57,16 @@ impl InstallSubcommand {
         lockfile.save(&self.project_path)?;
 
         let root_package_id = PackageId::new(manifest.package.name, manifest.package.version);
-        let installation = InstallationContext::new(&self.project_path);
+        let installation =
+            InstallationContext::new(&self.project_path, manifest.place.shared_packages);
+
         installation.clean()?;
-        installation.install(&package_sources, root_package_id, &resolved)?;
+        installation.install(
+            &package_sources,
+            root_package_id,
+            manifest.package.realm,
+            &resolved,
+        )?;
 
         Ok(())
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -61,12 +61,7 @@ impl InstallSubcommand {
             InstallationContext::new(&self.project_path, manifest.place.shared_packages);
 
         installation.clean()?;
-        installation.install(
-            &package_sources,
-            root_package_id,
-            manifest.package.realm,
-            &resolved,
-        )?;
+        installation.install(&package_sources, root_package_id, &resolved)?;
 
         Ok(())
     }

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -6,7 +6,7 @@ use std::{
 
 use anyhow::format_err;
 use fs_err as fs;
-use indoc::formatdoc;
+use indoc::{formatdoc, indoc};
 
 use crate::{
     manifest::Realm, package_contents::PackageContents, package_id::PackageId,
@@ -24,7 +24,7 @@ pub struct InstallationContext {
 
 impl InstallationContext {
     /// Create a new `InstallationContext` for the given path.
-    pub fn new(project_path: &Path) -> Self {
+    pub fn new(project_path: &Path, shared_path: Option<String>) -> Self {
         let shared_dir = project_path.join("Packages");
         let shared_index_dir = shared_dir.join("_Index");
         let server_dir = project_path.join("ServerPackages");
@@ -33,7 +33,7 @@ impl InstallationContext {
         Self {
             shared_dir,
             shared_index_dir,
-            shared_path: None,
+            shared_path,
             server_dir,
             server_index_dir,
             server_path: None,
@@ -64,6 +64,7 @@ impl InstallationContext {
         &self,
         sources: &PackageSourceMap,
         root_package_id: PackageId,
+        root_package_realm: Realm,
         resolved: &Resolve,
     ) -> anyhow::Result<()> {
         for package_id in &resolved.activated {
@@ -76,11 +77,11 @@ impl InstallationContext {
             // package links for its dependencies.
             if package_id == &root_package_id {
                 if let Some(deps) = shared_deps {
-                    self.write_root_package_links(Realm::Shared, deps)?;
+                    self.write_root_package_links(root_package_realm, deps, Realm::Shared)?;
                 }
 
                 if let Some(deps) = server_deps {
-                    self.write_root_package_links(Realm::Server, deps)?;
+                    self.write_root_package_links(root_package_realm, deps, Realm::Server)?;
                 }
             } else {
                 let metadata = resolved.metadata.get(package_id).unwrap();
@@ -133,10 +134,14 @@ impl InstallationContext {
     /// Contents of a link into the shared index from outside the shared index.
     fn link_shared_index(&self, id: &PackageId) -> anyhow::Result<String> {
         let shared_path = self.shared_path.as_ref().ok_or_else(|| {
-            format_err!(
-                "Cannot have server dependencies depend on \
-                 shared dependencies without shared_path set"
-            )
+            format_err!(indoc! {r#"
+                A Server dependency is depending on a shared dependency.
+                To link these packages correctly you must declare the shared
+                package location in your wally.toml. This typically looks like:
+
+                [place]
+                shared-packages = "game.ReplicatedStorage.Packages"
+            "#})
         })?;
 
         let contents = formatdoc! {r#"
@@ -176,12 +181,13 @@ impl InstallationContext {
 
     fn write_root_package_links<'a, K: Display>(
         &self,
-        realm: Realm,
+        package_realm: Realm,
         dependencies: impl IntoIterator<Item = (K, &'a PackageId)>,
+        dependencies_realm: Realm,
     ) -> anyhow::Result<()> {
         log::debug!("Writing root package links");
 
-        let base_path = match realm {
+        let base_path = match package_realm {
             Realm::Shared => &self.shared_dir,
             Realm::Server => &self.server_dir,
         };
@@ -191,7 +197,12 @@ impl InstallationContext {
 
         for (dep_name, dep_package_id) in dependencies {
             let path = base_path.join(format!("{}.lua", dep_name));
-            let contents = self.link_root_same_index(dep_package_id);
+
+            let contents = match (package_realm, dependencies_realm) {
+                (source, dest) if source == dest => self.link_root_same_index(dep_package_id),
+                (_, Realm::Server) => self.link_server_index(dep_package_id)?,
+                (_, Realm::Shared) => self.link_shared_index(dep_package_id)?,
+            };
 
             log::trace!("Writing {}", path.display());
             fs::write(path, contents)?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -18,6 +18,9 @@ pub struct Manifest {
     pub package: Package,
 
     #[serde(default)]
+    pub place: PlaceInfo,
+
+    #[serde(default)]
     pub dependencies: BTreeMap<String, PackageReq>,
 
     #[serde(default)]
@@ -92,6 +95,26 @@ pub struct Package {
     /// Example: ["Biff Lumfer <biff@playadopt.me>"]
     #[serde(default)]
     pub authors: Vec<String>,
+}
+
+// Metadata we require when this manifest will be used to generate package folders
+// This information can be present in any package but is only used in the root package
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PlaceInfo {
+    /// Where the shared packages folder is located in the Roblox Datamodel
+    ///
+    /// Example: `game.ReplicatedStorage.Packages`
+    #[serde(default)]
+    pub shared_packages: Option<String>,
+}
+
+impl Default for PlaceInfo {
+    fn default() -> Self {
+        Self {
+            shared_packages: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -100,8 +100,9 @@ impl PackageSource for Registry {
 
         if !response.status().is_success() {
             bail!(
-                "Failed to download package {} from registry: {}",
+                "Failed to download package {} from registry: {} \nResponse: {}",
                 package_id,
+                self.api_url()?,
                 response.status()
             );
         }

--- a/src/test_package.rs
+++ b/src/test_package.rs
@@ -37,6 +37,7 @@ impl PackageBuilder {
                 license: None,
                 authors: Vec::new(),
             },
+            place: Default::default(),
             dependencies: Default::default(),
             server_dependencies: Default::default(),
             dev_dependencies: Default::default(),


### PR DESCRIPTION
We want to reduce the number of packages we have in the datamodel, primarily this means keeping only one copy of each package. Some packages in the server realm will depend on shared packages, however due to this optimisation they will be held in separate locations in the datamodel. 

To allow server packages to require shared packages we can generate links which reference across realms. This is notable because we cannot generate these links as relative paths. We also don't know the absolute location of where shared packages are as Rojo manages their location.

In order to know where the shared packages are to generate these cross realm links an additional field has been added to the wally.toml. As an example the wally.toml may look like this.

```toml
[package]
name = "magnalite/my-package"
version = "1.4.2"
license = "Apache-2.0"
registry = "https://github.com/UpliftGames/wally-index"
realm = "server"

[place]
shared-packages = "game.ReplicatedStorage.Packages"

[dependencies]
Promise = "evaera/promise@3.1.0"

```

I see it fit to put this in the "place" table to emphasise this is metadata describing the place it will be sync'd into and not information related to the package itself. This can also be where we add any further metadata about where the package will be sync'd we may require.