### PR TITLE
Adds vendored-libgit2 feature from git2 library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.17"
+version = "0.13.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
+checksum = "2a8057932925d3a9d9e4434ea016570d37420ddb1ceed45a174d577f24ed6700"
 dependencies = [
  "bitflags",
  "libc",
@@ -1004,9 +1004,9 @@ checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.18+1.1.0"
+version = "0.12.24+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da6a42da88fc37ee1ecda212ffa254c25713532980005d5f7c0b0fbe7e6e885"
+checksum = "ddbd6021eef06fb289a8f54b3c2acfdd85ff2a585dfbb24b8576325373d2152c"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ blake3 = "0.3.7"
 dirs = "3.0.1"
 env_logger = "0.8.1"
 fs-err = "2.5.0"
-git2 = "0.13.11"
+git2 = "0.13.23"
 hex = "0.4.2"
 indoc = "1.0.3"
 log = "0.4.11"
@@ -55,3 +55,6 @@ zip = "0.5.11"
 
 [dev-dependencies]
 insta = "1.1.0"
+
+[features]
+vendored-libgit2 = ["git2/vendored-libgit2"]


### PR DESCRIPTION
On Arch linux based distributions it seems that system's libgit2 is incompatible with git2 crate, so a workaround that git2 has provided is to give an option to compile libgit2 from source while building the project.

If anyone building Wally from source sees the following error `invalid version 0 on git_proxy_options`, they can build the crate using vendored libgit2: `cargo build --features vendored-libgit2`.