### PR TITLE
Enforce minimum wally version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Backend API for package metadata and search ([#46][#46])
 * Arch users can now use vendored-libgit2 btw ([#52][#52])
 * Frontend can search packages and display package info ([#55][#55])
+* Minimum Wally version enforcement by registry ([#57][#57])
 
 [#15]: https://github.com/UpliftGames/wally/issues/15
 [#35]: https://github.com/UpliftGames/wally/pull/35
@@ -17,6 +18,7 @@
 [#46]: https://github.com/UpliftGames/wally/pull/46
 [#52]: https://github.com/UpliftGames/wally/pull/52
 [#55]: https://github.com/UpliftGames/wally/pull/55
+[#57]: https://github.com/UpliftGames/wally/pull/57
 
 ## 0.2.1 (2021-10-01)
 * First iteration of wally frontend. ([#32][#32])

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -9,6 +9,8 @@ use crate::{
     package_index::PackageIndex, GlobalOptions,
 };
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// Publish this project to a registry.
 #[derive(Debug, StructOpt)]
 pub struct PublishSubcommand {
@@ -56,6 +58,7 @@ impl PublishSubcommand {
         let response = client
             .post(api.join("/v1/publish")?)
             .header("accept", "application/json")
+            .header("Wally-Version", VERSION)
             .bearer_auth(auth)
             .body(contents.data().to_owned())
             .send()?;

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -15,6 +15,8 @@ use crate::package_source::{PackageContents, PackageSource};
 
 use super::PackageSourceId;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub struct Registry {
     index_url: Url,
     auth_token: OnceCell<Option<Arc<str>>>,
@@ -91,7 +93,7 @@ impl PackageSource for Registry {
 
         let url = self.api_url()?.join(&path)?;
 
-        let mut request = self.client.get(url);
+        let mut request = self.client.get(url).header("Wally-Version", VERSION);
 
         if let Some(token) = self.auth_token()? {
             request = request.header(AUTHORIZATION, format!("Bearer {}", token));
@@ -100,10 +102,11 @@ impl PackageSource for Registry {
 
         if !response.status().is_success() {
             bail!(
-                "Failed to download package {} from registry: {} \nResponse: {}",
+                "Failed to download package {} from registry: {}\n{} {}",
                 package_id,
                 self.api_url()?,
-                response.status()
+                response.status(),
+                response.text()?
             );
         }
 

--- a/wally-registry-backend/src/config.rs
+++ b/wally-registry-backend/src/config.rs
@@ -1,3 +1,4 @@
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -18,4 +19,7 @@ pub struct Config {
 
     /// Which storage backend to use.
     pub storage: StorageMode,
+
+    /// The minimum wally cli version required to publish to the registry
+    pub minimum_wally_version: Option<Version>,
 }

--- a/wally-registry-backend/src/error.rs
+++ b/wally-registry-backend/src/error.rs
@@ -4,6 +4,8 @@ use std::io::Cursor;
 
 use rocket::{
     http::{ContentType, Status},
+    outcome::Outcome::Failure,
+    request::Outcome,
     response::Responder,
     Request, Response,
 };
@@ -38,6 +40,7 @@ where
 /// Error type returned by most API endpoints. This type has automatic
 /// conversions from pretty much any error type and uses an `anyhow::Error`
 /// internally.
+#[derive(Debug)]
 pub struct Error {
     message: String,
     status: Status,
@@ -64,6 +67,15 @@ where
             message: format!("{:?}", error.into()),
             status: Status::InternalServerError,
         }
+    }
+}
+
+impl<S, E> From<Error> for Outcome<S, E>
+where
+    E: From<Error>,
+{
+    fn from(err: Error) -> Self {
+        Failure((Status::InternalServerError, err.into()))
     }
 }
 

--- a/wally-registry-backend/src/main.rs
+++ b/wally-registry-backend/src/main.rs
@@ -128,8 +128,8 @@ async fn publish(
     _cli_version: Result<WallyVersion, Error>,
     data: Data,
 ) -> Result<Json<serde_json::Value>, Error> {
-    let authorization = authorization?;
     _cli_version?;
+    let authorization = authorization?;
 
     let contents = data
         .open(2.mebibytes())

--- a/wally-registry-backend/src/main.rs
+++ b/wally-registry-backend/src/main.rs
@@ -27,6 +27,7 @@ use libwally::{
 };
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::Header;
+use rocket::request::{FromRequest, Outcome};
 use rocket::{
     data::{Data, ToByteUnit},
     fairing::AdHoc,
@@ -57,11 +58,15 @@ fn root() -> Json<serde_json::Value> {
 #[get("/v1/package-contents/<scope>/<name>/<version>")]
 async fn package_contents(
     storage: State<'_, Box<dyn StorageBackend>>,
-    _read: ReadAccess,
+    _read: Result<ReadAccess, Error>,
     scope: String,
     name: String,
     version: String,
+    _cli_version: Result<WallyVersion, Error>,
 ) -> Result<Content<Stream<StorageOutput>>, Error> {
+    _read?;
+    _cli_version?;
+
     let package_name = PackageName::new(scope, name)
         .context("error parsing package name")
         .status(Status::BadRequest)?;
@@ -80,10 +85,12 @@ async fn package_contents(
 #[get("/v1/package-metadata/<scope>/<name>")]
 async fn package_info(
     index: State<'_, PackageIndex>,
-    _read: ReadAccess,
+    _read: Result<ReadAccess, Error>,
     scope: String,
     name: String,
 ) -> Result<Json<serde_json::Value>, Error> {
+    _read?;
+
     let package_name = PackageName::new(scope, name)
         .context("error parsing package name")
         .status(Status::BadRequest)?;
@@ -96,9 +103,11 @@ async fn package_info(
 #[get("/v1/package-search?<query>")]
 async fn package_search(
     search_backend: State<'_, RwLock<SearchBackend>>,
-    _read: ReadAccess,
+    _read: Result<ReadAccess, Error>,
     query: String,
 ) -> Result<Json<serde_json::Value>, Error> {
+    _read?;
+
     if let Ok(search_backend) = search_backend.read() {
         let result = search_backend.search(&query)?;
         Ok(Json(serde_json::to_value(result)?))
@@ -115,9 +124,13 @@ async fn publish(
     storage: State<'_, Box<dyn StorageBackend>>,
     search_backend: State<'_, RwLock<SearchBackend>>,
     index: State<'_, PackageIndex>,
-    authorization: WriteAccess,
+    authorization: Result<WriteAccess, Error>,
+    _cli_version: Result<WallyVersion, Error>,
     data: Data,
 ) -> Result<Json<serde_json::Value>, Error> {
+    let authorization = authorization?;
+    _cli_version?;
+
     let contents = data
         .open(2.mebibytes())
         .into_bytes()
@@ -151,8 +164,8 @@ async fn publish(
         let user_id = github_info.id();
         let scope = package_id.name().scope();
 
-        if !index.is_scope_owner(&scope, &user_id)? {
-            index.add_scope_owner(&scope, &user_id)?;
+        if !index.is_scope_owner(scope, user_id)? {
+            index.add_scope_owner(scope, user_id)?;
         }
     }
 
@@ -274,7 +287,57 @@ impl Fairing for Cors {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
         response.set_header(Header::new("Access-Control-Allow-Methods", "GET"));
         response.set_header(Header::new("Access-Control-Allow-Headers", "*"));
-        response.set_header(Header::new("Access-Control-Allow-Credentials", "true"));
+    }
+}
+
+struct WallyVersion;
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for WallyVersion {
+    type Error = Error;
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let config = request
+            .guard::<State<Config>>()
+            .await
+            .expect("Failed to load config");
+
+        let minimum_version = match &config.minimum_wally_version {
+            Some(version) => version,
+            None => return Outcome::Success(WallyVersion),
+        };
+
+        let version = match request.headers().get_one("Wally-Version") {
+            Some(version) => version,
+            None => {
+                return format_err!(
+                    "Wally version header required. Try upgrading your wally installation."
+                )
+                .status(Status::BadRequest)
+                .into();
+            }
+        };
+
+        let version = match Version::parse(version) {
+            Ok(version) => version,
+            Err(err) => {
+                return format_err!("Failed to parse wally version header: {}", err)
+                    .status(Status::BadRequest)
+                    .into();
+            }
+        };
+
+        if &version < minimum_version {
+            format_err!(
+                "This registry requires Wally {} (you are using {})",
+                minimum_version,
+                version
+            )
+            .status(Status::BadRequest)
+            .into()
+        } else {
+            Outcome::Success(WallyVersion)
+        }
     }
 }
 

--- a/wally-registry-backend/src/tests/mod.rs
+++ b/wally-registry-backend/src/tests/mod.rs
@@ -59,6 +59,7 @@ fn new_client_with_remote(auth: AuthMode, index_url: url::Url) -> Client {
         },
         auth,
         github_token: None,
+        minimum_wally_version: None,
     }));
 
     Client::tracked(server(figment)).expect("valid rocket instance")


### PR DESCRIPTION
This PR adds a way to ensure clients interacting with a registry have a minimum Wally cli version. It also changes the way request guards are used so errors can be propagated back as expected.