### PR TITLE
Add filter for pre-release packages on Package page

### DIFF
--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -110,7 +110,14 @@ export default function Package() {
   const loadPackageData = async (packageScope: string, packageName: string) => {
     const packageData = await getWallyPackageMetadata(packageScope, packageName)
     if (packageData !== undefined) {
-      setPackageMetadata(packageData.versions[0])
+      const filteredPackageData = packageData.versions.some(
+        (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
+      )
+        ? packageData.versions.filter(
+            (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
+          )
+        : packageData
+      setPackageMetadata(filteredPackageData[0])
       setIsLoaded(true)
     } else {
       setIsError(true)


### PR DESCRIPTION
This change filters out pre-release package information on the Package page. This enables the package metadata for each Wally entry to be the latest mainline-release, impacting the description, version history, and the install code button.