### PR TITLE
Fix using packages with dev dependencies

### DIFF
--- a/src/installation.rs
+++ b/src/installation.rs
@@ -112,10 +112,6 @@ impl InstallationContext {
                     self.write_package_links(package_id, package_realm, deps, Realm::Server)?;
                 }
 
-                if let Some(deps) = dev_deps {
-                    self.write_package_links(package_id, package_realm, deps, Realm::Dev)?;
-                }
-
                 let source_registry = &resolved.metadata[package_id].source_registry;
                 let package_source = sources.get(source_registry).unwrap();
                 let contents = package_source.download_package(package_id)?;

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -228,7 +228,7 @@ impl InstallationContext {
                 (_, Realm::Server) => self.link_server_index(dep_package_id)?,
                 (_, Realm::Shared) => self.link_shared_index(dep_package_id)?,
                 (_, Realm::Dev) => {
-                    bail!("A dev dependency cannot be dependened upon by a non-dev dependency")
+                    bail!("A dev dependency cannot be depended upon by a non-dev dependency")
                 }
             };
 
@@ -267,7 +267,7 @@ impl InstallationContext {
                 (_, Realm::Server) => self.link_server_index(dep_package_id)?,
                 (_, Realm::Shared) => self.link_shared_index(dep_package_id)?,
                 (_, Realm::Dev) => {
-                    bail!("A dev dependency cannot be dependened upon by a non-dev dependency")
+                    bail!("A dev dependency cannot be depended upon by a non-dev dependency")
                 }
             };
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -261,16 +261,6 @@ pub fn resolve(
                 })
             }
 
-            for (alias, req) in &candidate.dev_dependencies {
-                packages_to_visit.push_back(DependencyRequest {
-                    request_source: candidate_id.clone(),
-                    request_realm: Realm::Dev,
-                    origin_realm: dependency_request.origin_realm,
-                    package_alias: alias.clone(),
-                    package_req: req.clone(),
-                })
-            }
-
             continue 'outer;
         }
 


### PR DESCRIPTION
This is a fix for #71. It stops wally install from resolving dev dependencies of nested packages, which I'm pretty sure is unintended behavior since it leads to a crash every time.

I have zero Rust experience so please be gentle. 😛 