### PR TITLE
Fix registry backend dockerfile command ordering

### DIFF
--- a/wally-registry-backend/Dockerfile
+++ b/wally-registry-backend/Dockerfile
@@ -30,10 +30,11 @@ FROM debian:buster-slim
 RUN apt-get update
 RUN apt-get install -y git ca-certificates libssl-dev && rm -rf /var/lib/apt/lists/*
 
+RUN useradd -ms /bin/bash 1000
+
 COPY --chown=1000 --from=build /usr/app/target/release/wally-registry-backend "/app/launch"
 COPY --chown=1000 --from=build /usr/app/wally-registry-backend/Rocket.toml "/app/Rocket.toml"
 
-RUN useradd -ms /bin/bash 1000
 USER 1000
 
 EXPOSE 8000


### PR DESCRIPTION
`chown=1000` was running before adding the user `1000`, making it fail if the user did not already exist.

This might be a vendor-specific thing / depend on if the backend is running in docker or another runtime such as podman, testing was done using DigitalOcean's App Platform where the backend fails to run without this fix.