### PR TITLE
Security hotfix: Implement functionality to ban GitHub user IDs

### DIFF
--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -149,7 +149,7 @@ impl WriteAccess {
             WriteAccess::Github(github_info) => {
                 let id = github_info.id();
 
-                if banned_github_ids.0.contains(id) {
+                if banned_github_ids.contains(id) {
                     // This user is banned from publishing any packages
                     return Ok(false);
                 }

--- a/wally-registry-backend/src/config.rs
+++ b/wally-registry-backend/src/config.rs
@@ -22,4 +22,7 @@ pub struct Config {
 
     /// The minimum wally cli version required to publish to the registry
     pub minimum_wally_version: Option<Version>,
+
+    /// List of GitHub user IDs that are banned from writing to any package.
+    pub banned_github_ids: Option<Vec<u64>>,
 }

--- a/wally-registry-backend/src/main.rs
+++ b/wally-registry-backend/src/main.rs
@@ -12,6 +12,7 @@ mod tests;
 
 use std::convert::TryInto;
 use std::io::{Cursor, Read, Seek};
+use std::ops::Deref;
 use std::sync::RwLock;
 
 use anyhow::{format_err, Context};
@@ -278,6 +279,14 @@ fn configure_gcs(bucket: String) -> anyhow::Result<GcsStorage> {
 
 #[derive(Debug)]
 pub struct BannedGithubIds(pub Vec<u64>);
+
+impl Deref for BannedGithubIds {
+    type Target = Vec<u64>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 struct Cors;
 

--- a/wally-registry-backend/src/tests/mod.rs
+++ b/wally-registry-backend/src/tests/mod.rs
@@ -60,6 +60,7 @@ fn new_client_with_remote(auth: AuthMode, index_url: url::Url) -> Client {
         auth,
         github_token: None,
         minimum_wally_version: None,
+        banned_github_ids: None,
     }));
 
     Client::tracked(server(figment)).expect("valid rocket instance")


### PR DESCRIPTION
Super quick hotfix for security vulnerability where users can take over org scopes if the corresponding GitHub org doesn't exist. Allows the banning of a malicious account on a case-by-case basis.

This implementation was discussed over Discord and is a temporary bandaid for a larger vulnerability that will take more time to fix.

I couldn't implement test cases without re-architecture because Wally's test setup doesn't support faking GitHub authentication. Ideally, you could mock HTTP requests to GitHub's API via a mock HTTP client, but this would take too much time to implement here.