### PR TITLE
Implement manual login parameters for login subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Wally Changelog
 
 ## Unreleased Changes
+* Support for directly providing token to `wally login` ([#105][#105])
 
 ## 0.3.1 (2021-11-12)
 * Support for dev dependencies ([#63][63])

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Parity with:
 ### `wally login`
 Log into an account to publish packages to a registry.
 
+You can also directly provide a token via `wally login --token "$WALLY_AUTH_TOKEN"`.
+
 Parity with:
 * `cargo login`
 * `npm login`


### PR DESCRIPTION
Implements new arguments for the `wally login` subcommand to facilitate easier login in CI environments.

The previous method for logging in using a GitHub Workflow involved manually copying the contents of the hidden auth file and doing something similar to this:

```yaml
run: |
  mkdir -p ~/.wally
  echo "$WALLY_AUTH" > ~/.wally/auth.toml
```

The new method only requires a valid auth token to be passed and is more future-proof if the auth file format changes:

```yaml
run: wally login --token "$WALLY_AUTH_TOKEN"
```