### PR TITLE
Version selection on package page

### DIFF
--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -164,7 +164,7 @@ export default function Package() {
 	if (packageVersion == undefined) {
 		const latestVersion = filteredPackageData[0].package.version
 		setPackageVersion(latestVersion)
-		hist.push(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
+		hist.replace(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
 	}
 
     setIsLoaded(true)

--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -244,7 +244,7 @@ export default function Package() {
                   <div
                     style={{
                       display: "grid",
-                      overflow: "scroll",
+                      overflow: "auto",
                       height: "7rem",
                     }}
                   >

--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -160,6 +160,13 @@ export default function Package() {
       : packageData
 
     setPackageHistory(filteredPackageData)
+
+	if (packageVersion == undefined) {
+		const latestVersion = filteredPackageData[0].package.version
+		setPackageVersion(latestVersion)
+		hist.push(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
+	}
+
     setIsLoaded(true)
   }
 

--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -203,7 +203,27 @@ export default function Package() {
                 )}
 
                 <MetaItem title="Version" width="half">
-                  {packageMetadata?.package.version || "?.?.?"}
+                  <select
+                    name="version"
+                    id="version-select"
+                    value={packageVersion || "?.?.?"}
+                    onChange={(a) => {
+                      hist.push(
+                        `/package/${packageScope}/${packageName}?version=${a.target.value}`
+                      )
+                    }}
+                  >
+                    {packageHistory?.map((item: WallyPackageMetadata) => {
+                      return (
+                        <option
+                          key={item.package.version}
+                          value={item.package.version}
+                        >
+                          {item.package.version}
+                        </option>
+                      )
+                    })}
+                  </select>
                 </MetaItem>
 
                 {packageMetadata?.package.license && (
@@ -239,36 +259,6 @@ export default function Package() {
                       ))}
                     </MetaItem>
                   )}
-
-                <MetaItem title="Versions" width="full">
-                  <div
-                    style={{
-                      display: "grid",
-                      overflow: "auto",
-                      height: "7rem",
-                    }}
-                  >
-                    {packageHistory?.map((item: WallyPackageMetadata) => {
-                      return (
-                        <a
-                          onClick={() => {
-                            hist.push(
-                              "/package/" +
-                                packageScope +
-                                "/" +
-                                packageName +
-                                "?version=" +
-                                item.package.version
-                            )
-                          }}
-                          style={{ cursor: "pointer" }}
-                        >
-                          {item.package.version}
-                        </a>
-                      )
-                    })}
-                  </div>
-                </MetaItem>
 
                 {packageMetadata?.dependencies &&
                   Object.values(packageMetadata?.dependencies).length > 0 && (


### PR DESCRIPTION
Turns the Version metadata into a dropdown, and allows users to inspect and install older versions.

![image](https://user-images.githubusercontent.com/40185666/223003691-3264e1f9-961f-4865-ae2d-60447117b10a.png)

Additionally, the URL will now include `?version=X.X.X`, allowing users to share links that are guaranteed to always be a specific version. This may be useful for project documentation where a specific version of a package is necessary. Sharing a link with no version param will make it default to the latest version.
The URL will remain up to date acc. to the user's selection, and supports back/forward navigation shortcuts. The addition of the latest version to a default link does not add a navigation waypoint, since there was no user action and should be silent.