### PR TITLE
Remove prerelease checks

### DIFF
--- a/wally-registry-backend/src/search.rs
+++ b/wally-registry-backend/src/search.rs
@@ -109,15 +109,11 @@ impl SearchBackend {
             for manifest in &(*metadata).versions {
                 doc.add_text(versions, manifest.package.version.to_string());
 
-                if !manifest.package.version.is_prerelease() {
-                    doc.add_text(scope, manifest.package.name.scope());
-                    doc.add_text(name, manifest.package.name.name());
+                doc.add_text(scope, manifest.package.name.scope());
+                doc.add_text(name, manifest.package.name.name());
 
-                    if let Some(description_text) = &manifest.package.description {
-                        doc.add_text(description, description_text);
-                    }
-
-                    break;
+                if let Some(description_text) = &manifest.package.description {
+                    doc.add_text(description, description_text);
                 }
             }
 

--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -150,21 +150,13 @@ export default function Package() {
       return
     }
 
-    const filteredPackageData = packageData.versions.some(
-      (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
-    )
-      ? packageData.versions.filter(
-          (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
-        )
-      : packageData
+    setPackageHistory(packageData)
 
-    setPackageHistory(filteredPackageData)
-
-	if (urlPackageVersion == null) {
-		const latestVersion = filteredPackageData[0].package.version
-		setPackageVersion(latestVersion)
-		hist.replace(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
-	}
+    if (urlPackageVersion == null) {
+      const latestVersion = packageData[0].package.version
+      setPackageVersion(latestVersion)
+      hist.replace(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
+    }
 
     setIsLoaded(true)
   }


### PR DESCRIPTION
This PR aims to remove prerelease checks so they can show up on the website and also ensure we show every version of packages. This may have unintended consequences and require a revert as the version handling logic here is unusually fragile.