### PR TITLE
Revert "Remove prerelease checks (#124)"

### DIFF
--- a/wally-registry-backend/src/search.rs
+++ b/wally-registry-backend/src/search.rs
@@ -109,11 +109,15 @@ impl SearchBackend {
             for manifest in &(*metadata).versions {
                 doc.add_text(versions, manifest.package.version.to_string());
 
-                doc.add_text(scope, manifest.package.name.scope());
-                doc.add_text(name, manifest.package.name.name());
+                if !manifest.package.version.is_prerelease() {
+                    doc.add_text(scope, manifest.package.name.scope());
+                    doc.add_text(name, manifest.package.name.name());
 
-                if let Some(description_text) = &manifest.package.description {
-                    doc.add_text(description, description_text);
+                    if let Some(description_text) = &manifest.package.description {
+                        doc.add_text(description, description_text);
+                    }
+
+                    break;
                 }
             }
 

--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -150,13 +150,21 @@ export default function Package() {
       return
     }
 
-    setPackageHistory(packageData)
+    const filteredPackageData = packageData.versions.some(
+      (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
+    )
+      ? packageData.versions.filter(
+          (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
+        )
+      : packageData
 
-    if (urlPackageVersion == null) {
-      const latestVersion = packageData[0].package.version
-      setPackageVersion(latestVersion)
-      hist.replace(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
-    }
+    setPackageHistory(filteredPackageData)
+
+	if (urlPackageVersion == null) {
+		const latestVersion = filteredPackageData[0].package.version
+		setPackageVersion(latestVersion)
+		hist.replace(`/package/${packageScope}/${packageName}?version=${latestVersion}`)
+	}
 
     setIsLoaded(true)
   }


### PR DESCRIPTION
This reverts commit 3fb7d. As expected this has unintended side effects and we will need to make extra changes to the frontend to handle the extra data it is now given. 