### PR TITLE
Parallel package install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1226,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db45317f37ef454e6519b6c3ed7d377e5f23346f0823f86e65ca36912d1d0ef8"
+dependencies = [
+ "console 0.15.7",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,7 +1259,7 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1b21a2971cea49ca4613c0e9fe8225ecaf5de64090fddc6002284726e9244"
 dependencies = [
- "console",
+ "console 0.14.1",
  "lazy_static",
  "serde",
  "serde_json",
@@ -1414,12 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "loom"
@@ -1658,6 +1681,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1876,12 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"
@@ -3421,6 +3456,7 @@ dependencies = [
  "git2",
  "globset",
  "hex",
+ "indicatif",
  "indoc",
  "insta",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +263,37 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.11",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -452,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -473,13 +510,13 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
@@ -738,6 +775,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -1252,7 +1298,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "similar",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1465,6 +1511,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1501,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
@@ -1516,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -1569,6 +1624,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "moka"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36506f2f935238463605f3bb13b362f1949daafc3b347d05d60ae08836db2bd2"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "quanta",
+ "rustc_version",
+ "scheduled-thread-pool",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid 1.3.3",
 ]
 
 [[package]]
@@ -1935,6 +2013,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+dependencies = [
+ "bitflags 1.3.2",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2022,6 +2127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
  "rand_core 0.6.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2485,6 +2599,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot 0.12.1",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2667,9 @@ name = "semver"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d92beeab217753479be2f74e54187a6aed4c125ff0703a866c3147a02f0c6dd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -2718,6 +2844,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2725,9 +2866,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
@@ -2846,6 +2987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,7 +3037,7 @@ dependencies = [
  "tantivy-query-grammar",
  "tempfile",
  "thiserror",
- "uuid",
+ "uuid 0.8.2",
  "winapi",
 ]
 
@@ -3250,6 +3397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +3446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b9bc53168a4be7402ab86c3aad243a84dd7381d09be0eddc81280c1da95ca68"
 dependencies = [
  "serde",
+ "version_check",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
  "version_check",
 ]
 
@@ -3389,6 +3551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+dependencies = [
+ "getrandom 0.2.2",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3648,7 @@ dependencies = [
  "futures",
  "git2",
  "glob",
+ "moka",
  "reqwest",
  "rocket",
  "rusoto_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-compression"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -140,6 +153,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "binascii"
@@ -1141,17 +1160,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+checksum = "0646026eb1b3eea4cd9ba47912ea5ce9cc07713d105b1a14698f4e6433d348b7"
 dependencies = [
- "futures-util",
+ "http",
  "hyper",
- "log",
  "rustls",
  "tokio",
  "tokio-rustls",
- "webpki",
 ]
 
 [[package]]
@@ -1531,7 +1548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
@@ -1576,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2111,15 +2127,17 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.2"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.13.0",
+ "async-compression",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "hyper",
@@ -2127,22 +2145,26 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
+ "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
  "winreg",
@@ -2381,15 +2403,33 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
- "base64 0.13.0",
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2437,9 +2477,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
@@ -2535,12 +2575,12 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.7",
+ "itoa 1.0.6",
  "ryu",
  "serde",
 ]
@@ -2994,32 +3034,31 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio 0.8.8",
  "num_cpus",
- "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.67",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -3034,13 +3073,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -3467,8 +3505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -3529,6 +3565,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
+name = "wasm-streams"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076e644811919817f3d28f9344a7d359d8a45cc72a7187c7ace7281d081a74ad"
+dependencies = [
+ "futures",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.4"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
 dependencies = [
  "ring",
  "untrusted",
@@ -3550,9 +3599,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.21.1"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -3750,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.7.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,19 +71,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
-name = "async-compression"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
-dependencies = [
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,7 +2153,6 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "async-compression",
  "base64 0.21.2",
  "bytes",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tempfile",
+ "tokio",
  "toml 0.5.8",
  "toml_edit 0.2.0",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ whoami = "1.1.2"
 zip = "0.5.11"
 globset = "0.4.8"
 indicatif = "0.17.4"
+tokio = "1.28.2"
 
 [dev-dependencies]
 insta = { version = "1.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ indoc = "1.0.3"
 log = "0.4.11"
 once_cell = "1.5.2"
 opener = "0.5.0"
-reqwest = { version = "0.11.18", features = ["blocking", "json", "gzip"] }
+reqwest = { version = "0.11.18", features = ["blocking", "json"] }
 rpassword = "5.0.1"
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.116", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ indoc = "1.0.3"
 log = "0.4.11"
 once_cell = "1.5.2"
 opener = "0.5.0"
-reqwest = { version = "0.11.0", features = ["blocking", "json"] }
+reqwest = { version = "0.11.18", features = ["blocking", "json", "gzip"] }
 rpassword = "5.0.1"
 semver = { version = "0.11.0", features = ["serde"] }
 serde = { version = "1.0.116", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ walkdir = "2.3.1"
 whoami = "1.1.2"
 zip = "0.5.11"
 globset = "0.4.8"
+indicatif = "0.17.4"
 
 [dev-dependencies]
 insta = { version = "1.1.0" }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -7,9 +7,7 @@ use crate::installation::InstallationContext;
 use crate::lockfile::{LockPackage, Lockfile};
 use crate::manifest::Manifest;
 use crate::package_id::PackageId;
-use crate::package_source::{
-    PackageSource, PackageSourceId, PackageSourceMap, Registry, TestRegistry,
-};
+use crate::package_source::{PackageSource, PackageSourceMap, Registry, TestRegistry};
 use crate::resolution::resolve;
 
 use super::GlobalOptions;

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -29,10 +29,14 @@ impl InstallSubcommand {
         let lockfile = Lockfile::load(&self.project_path)?
             .unwrap_or_else(|| Lockfile::from_manifest(&manifest));
 
-        let default_registry: Box<dyn PackageSource> = if global.test_registry {
-            Box::new(TestRegistry::new(&manifest.package.registry))
+        let default_registry: Box<PackageSource> = if global.test_registry {
+            Box::new(PackageSource::TestRegistry(TestRegistry::new(
+                &manifest.package.registry,
+            )))
         } else {
-            Box::new(Registry::from_registry_spec(&manifest.package.registry)?)
+            Box::new(PackageSource::Registry(Registry::from_registry_spec(
+                &manifest.package.registry,
+            )?))
         };
 
         let mut package_sources = PackageSourceMap::new(default_registry);
@@ -64,7 +68,7 @@ impl InstallSubcommand {
         );
 
         installation.clean()?;
-        installation.install(&package_sources, root_package_id, &resolved)?;
+        installation.install(package_sources, root_package_id, resolved)?;
 
         Ok(())
     }

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -145,7 +145,7 @@ impl InstallationContext {
                 let context = self.clone();
                 let b = bar.clone();
 
-                let handle = runtime.spawn(async move {
+                let handle = runtime.spawn_blocking(move || {
                     let package_source = source_copy.get(&source_registry).unwrap();
                     let contents = package_source.download_package(&package_id)?;
                     b.println(format!(

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -2,6 +2,7 @@ use std::{
     fmt::Display,
     io,
     path::{Path, PathBuf},
+    thread,
 };
 
 use anyhow::{bail, format_err};
@@ -77,7 +78,7 @@ impl InstallationContext {
     /// Install all packages from the given `Resolve` into the package that this
     /// `InstallationContext` was built for.
     pub fn install(
-        &self,
+        self,
         sources: PackageSourceMap,
         root_package_id: PackageId,
         resolved: Resolve,
@@ -124,9 +125,9 @@ impl InstallationContext {
 
                 let source_registry = resolved_copy.metadata[&package_id].source_registry.clone();
                 let source_copy = sources.clone();
-                let context = (*self).clone();
+                let context = self.clone();
 
-                let handle = std::thread::spawn(move || {
+                let handle = thread::spawn(move || {
                     let package_source = source_copy.get(&source_registry).unwrap();
                     let contents = package_source.download_package(&package_id)?;
                     context.write_contents(&package_id, &contents, package_realm)

--- a/src/installation.rs
+++ b/src/installation.rs
@@ -14,7 +14,7 @@ use crate::{
     manifest::Realm,
     package_contents::PackageContents,
     package_id::PackageId,
-    package_source::{PackageSourceImpl, PackageSourceMap},
+    package_source::{PackageSourceMap, PackageSourceProvider},
     resolution::Resolve,
 };
 

--- a/src/package_source.rs
+++ b/src/package_source.rs
@@ -3,6 +3,7 @@ mod registry;
 mod test_registry;
 
 pub use self::in_memory::InMemoryRegistry;
+use self::in_memory::InMemoryRegistrySource;
 pub use self::registry::Registry;
 pub use self::test_registry::TestRegistry;
 
@@ -23,13 +24,14 @@ pub enum PackageSourceId {
     Path(PathBuf),
 }
 
+#[derive(Clone)]
 pub struct PackageSourceMap {
-    sources: HashMap<PackageSourceId, Box<dyn PackageSource>>,
+    sources: HashMap<PackageSourceId, Box<PackageSource>>,
     source_order: Vec<PackageSourceId>,
 }
 
 impl PackageSourceMap {
-    pub fn new(default_registry: Box<dyn PackageSource>) -> Self {
+    pub fn new(default_registry: Box<PackageSource>) -> Self {
         let mut sources = HashMap::new();
         sources.insert(PackageSourceId::DefaultRegistry, default_registry);
 
@@ -39,7 +41,7 @@ impl PackageSourceMap {
         }
     }
 
-    pub fn get(&self, id: &PackageSourceId) -> Option<&dyn PackageSource> {
+    pub fn get(&self, id: &PackageSourceId) -> Option<&PackageSource> {
         self.sources.get(id).map(|source| source.as_ref())
     }
 
@@ -59,9 +61,13 @@ impl PackageSourceMap {
             for fallback in registry.fallback_sources()? {
                 // Prevent circular references by only adding new sources
                 if !self.source_order.contains(&fallback) {
-                    let source: Box<dyn PackageSource> = match &fallback {
-                        PackageSourceId::Git(url) => Box::new(Registry::from_registry_spec(url)?),
-                        PackageSourceId::Path(path) => Box::new(TestRegistry::new(path.clone())),
+                    let source: Box<PackageSource> = match &fallback {
+                        PackageSourceId::Git(url) => {
+                            Box::new(PackageSource::Registry(Registry::from_registry_spec(url)?))
+                        }
+                        PackageSourceId::Path(path) => {
+                            Box::new(PackageSource::TestRegistry(TestRegistry::new(path.clone())))
+                        }
                         PackageSourceId::DefaultRegistry => {
                             panic!("Default registry should never be added as a fallback source!")
                         }
@@ -79,7 +85,7 @@ impl PackageSourceMap {
     }
 }
 
-pub trait PackageSource {
+pub trait PackageSourceImpl: Sync + Send + Clone {
     /// Update this package source, if it has state that needs to be updated.
     fn update(&self) -> anyhow::Result<()>;
 
@@ -93,4 +99,45 @@ pub trait PackageSource {
 
     /// Provide a list of fallback sources to search if this source can't provide a package
     fn fallback_sources(&self) -> anyhow::Result<Vec<PackageSourceId>>;
+}
+
+#[derive(Clone)]
+pub enum PackageSource {
+    InMemory(InMemoryRegistrySource),
+    Registry(Registry),
+    TestRegistry(TestRegistry),
+}
+
+impl PackageSourceImpl for PackageSource {
+    fn update(&self) -> anyhow::Result<()> {
+        match self {
+            PackageSource::InMemory(source) => source.update(),
+            PackageSource::Registry(source) => source.update(),
+            PackageSource::TestRegistry(source) => source.update(),
+        }
+    }
+
+    fn query(&self, package_req: &PackageReq) -> anyhow::Result<Vec<Manifest>> {
+        match self {
+            PackageSource::InMemory(source) => source.query(package_req),
+            PackageSource::Registry(source) => source.query(package_req),
+            PackageSource::TestRegistry(source) => source.query(package_req),
+        }
+    }
+
+    fn download_package(&self, package_id: &PackageId) -> anyhow::Result<PackageContents> {
+        match self {
+            PackageSource::InMemory(source) => source.download_package(package_id),
+            PackageSource::Registry(source) => source.download_package(package_id),
+            PackageSource::TestRegistry(source) => source.download_package(package_id),
+        }
+    }
+
+    fn fallback_sources(&self) -> anyhow::Result<Vec<PackageSourceId>> {
+        match self {
+            PackageSource::InMemory(source) => source.fallback_sources(),
+            PackageSource::Registry(source) => source.fallback_sources(),
+            PackageSource::TestRegistry(source) => source.fallback_sources(),
+        }
+    }
 }

--- a/src/package_source.rs
+++ b/src/package_source.rs
@@ -85,7 +85,7 @@ impl PackageSourceMap {
     }
 }
 
-pub trait PackageSourceImpl: Sync + Send + Clone {
+pub trait PackageSourceProvider: Sync + Send + Clone {
     /// Update this package source, if it has state that needs to be updated.
     fn update(&self) -> anyhow::Result<()>;
 
@@ -108,7 +108,7 @@ pub enum PackageSource {
     TestRegistry(TestRegistry),
 }
 
-impl PackageSourceImpl for PackageSource {
+impl PackageSourceProvider for PackageSource {
     fn update(&self) -> anyhow::Result<()> {
         match self {
             PackageSource::InMemory(source) => source.update(),

--- a/src/package_source/in_memory.rs
+++ b/src/package_source/in_memory.rs
@@ -2,9 +2,10 @@
 //! memory. It's useful for creating exact conditions for test cases for
 //! resolution, installation, upgrading, etc.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::RwLock;
+use std::{cell::RefCell, sync::Arc};
 
 use anyhow::format_err;
 
@@ -13,7 +14,7 @@ use crate::{
     package_source::PackageSource, test_package::PackageBuilder,
 };
 
-use super::{PackageContents, PackageSourceId};
+use super::{PackageContents, PackageSourceId, PackageSourceImpl};
 
 /// An in-memory registry that can have packages published to it.
 ///
@@ -32,7 +33,7 @@ impl InMemoryRegistry {
 
     /// Publish a new package to the registry.
     pub fn publish(&self, builder: PackageBuilder) {
-        let mut storage = self.storage.contents.borrow_mut();
+        let mut storage = self.storage.contents.write().unwrap();
         let (manifest, contents) = builder.package();
 
         let scope = storage
@@ -47,26 +48,27 @@ impl InMemoryRegistry {
     }
 
     /// Returns a handle to an object that can be used as a `PackageSource`.
-    pub fn source(&self) -> InMemoryRegistrySource {
-        InMemoryRegistrySource {
+    pub fn source(&self) -> PackageSource {
+        PackageSource::InMemory(InMemoryRegistrySource {
             storage: self.storage.clone(),
-        }
+        })
     }
 }
 
 /// Returned by `InMemoryRegistry::source` and can be passed to package
 /// resolution code in order to tell it to use this package registry.
+#[derive(Clone)]
 pub struct InMemoryRegistrySource {
     storage: Storage,
 }
 
-impl PackageSource for InMemoryRegistrySource {
+impl PackageSourceImpl for InMemoryRegistrySource {
     fn update(&self) -> anyhow::Result<()> {
         Ok(())
     }
 
     fn query(&self, package_req: &PackageReq) -> anyhow::Result<Vec<Manifest>> {
-        let storage = self.storage.contents.borrow();
+        let storage = self.storage.contents.read().unwrap();
         let scope = match storage.get(package_req.name().scope()) {
             Some(scope) => scope,
             None => return Ok(Vec::new()),
@@ -92,7 +94,7 @@ impl PackageSource for InMemoryRegistrySource {
     }
 
     fn download_package(&self, package_id: &PackageId) -> anyhow::Result<PackageContents> {
-        let storage = self.storage.contents.borrow();
+        let storage = self.storage.contents.read().unwrap();
         let scope = storage
             .get(package_id.name().scope())
             .ok_or_else(|| format_err!("Package {} does not exist", package_id))?;
@@ -121,5 +123,5 @@ struct PackageEntry {
 
 #[derive(Clone, Default)]
 struct Storage {
-    contents: Rc<RefCell<HashMap<String, HashMap<String, Vec<PackageEntry>>>>>,
+    contents: Arc<RwLock<HashMap<String, HashMap<String, Vec<PackageEntry>>>>>,
 }

--- a/src/package_source/in_memory.rs
+++ b/src/package_source/in_memory.rs
@@ -3,9 +3,8 @@
 //! resolution, installation, upgrading, etc.
 
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::sync::RwLock;
-use std::{cell::RefCell, sync::Arc};
 
 use anyhow::format_err;
 
@@ -14,7 +13,7 @@ use crate::{
     package_source::PackageSource, test_package::PackageBuilder,
 };
 
-use super::{PackageContents, PackageSourceId, PackageSourceImpl};
+use super::{PackageContents, PackageSourceId, PackageSourceProvider};
 
 /// An in-memory registry that can have packages published to it.
 ///
@@ -62,7 +61,7 @@ pub struct InMemoryRegistrySource {
     storage: Storage,
 }
 
-impl PackageSourceImpl for InMemoryRegistrySource {
+impl PackageSourceProvider for InMemoryRegistrySource {
     fn update(&self) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -36,7 +36,7 @@ impl Registry {
             index_url,
             auth_token: OnceCell::new(),
             index: OnceCell::new(),
-            client: ClientBuilder::new().gzip(true).build()?,
+            client: ClientBuilder::new().build()?,
         })
     }
 
@@ -112,8 +112,6 @@ impl PackageSourceProvider for Registry {
 
         let mut data = Vec::new();
         response.read_to_end(&mut data)?;
-
-        //log::info!("Downloaded {}...", package_id);
 
         Ok(PackageContents::from_buffer(data))
     }

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use once_cell::sync::OnceCell;
-use reqwest::blocking::ClientBuilder;
 use reqwest::{blocking::Client, header::AUTHORIZATION};
 use url::Url;
 
@@ -36,7 +35,7 @@ impl Registry {
             index_url,
             auth_token: OnceCell::new(),
             index: OnceCell::new(),
-            client: ClientBuilder::new().build()?,
+            client: Client::new(),
         })
     }
 

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -14,7 +14,7 @@ use crate::package_index::PackageIndex;
 use crate::package_req::PackageReq;
 use crate::package_source::PackageContents;
 
-use super::{PackageSourceId, PackageSourceImpl};
+use super::{PackageSourceId, PackageSourceProvider};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -64,7 +64,7 @@ impl Registry {
     }
 }
 
-impl PackageSourceImpl for Registry {
+impl PackageSourceProvider for Registry {
     fn update(&self) -> anyhow::Result<()> {
         self.index()?.update()
     }

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use once_cell::sync::OnceCell;
+use reqwest::blocking::ClientBuilder;
 use reqwest::{blocking::Client, header::AUTHORIZATION};
 use url::Url;
 
@@ -11,7 +12,7 @@ use crate::manifest::Manifest;
 use crate::package_id::PackageId;
 use crate::package_index::PackageIndex;
 use crate::package_req::PackageReq;
-use crate::package_source::{PackageContents, PackageSource};
+use crate::package_source::PackageContents;
 
 use super::{PackageSourceId, PackageSourceImpl};
 
@@ -35,7 +36,7 @@ impl Registry {
             index_url,
             auth_token: OnceCell::new(),
             index: OnceCell::new(),
-            client: Client::new(),
+            client: ClientBuilder::new().gzip(true).build()?,
         })
     }
 

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -113,7 +113,7 @@ impl PackageSourceImpl for Registry {
         let mut data = Vec::new();
         response.read_to_end(&mut data)?;
 
-        log::info!("Downloaded {}...", package_id);
+        //log::info!("Downloaded {}...", package_id);
 
         Ok(PackageContents::from_buffer(data))
     }

--- a/src/package_source/test_registry.rs
+++ b/src/package_source/test_registry.rs
@@ -8,9 +8,9 @@ use crate::manifest::Manifest;
 use crate::package_id::PackageId;
 use crate::package_index::PackageIndexConfig;
 use crate::package_req::PackageReq;
-use crate::package_source::{PackageContents, PackageSource};
+use crate::package_source::PackageContents;
 
-use super::{PackageSourceId, PackageSourceImpl};
+use super::{PackageSourceId, PackageSourceProvider};
 
 #[derive(Clone)]
 pub struct TestRegistry {
@@ -23,7 +23,7 @@ impl TestRegistry {
     }
 }
 
-impl PackageSourceImpl for TestRegistry {
+impl PackageSourceProvider for TestRegistry {
     fn update(&self) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/package_source/test_registry.rs
+++ b/src/package_source/test_registry.rs
@@ -10,8 +10,9 @@ use crate::package_index::PackageIndexConfig;
 use crate::package_req::PackageReq;
 use crate::package_source::{PackageContents, PackageSource};
 
-use super::PackageSourceId;
+use super::{PackageSourceId, PackageSourceImpl};
 
+#[derive(Clone)]
 pub struct TestRegistry {
     path: PathBuf,
 }
@@ -22,7 +23,7 @@ impl TestRegistry {
     }
 }
 
-impl PackageSource for TestRegistry {
+impl PackageSourceImpl for TestRegistry {
     fn update(&self) -> anyhow::Result<()> {
         Ok(())
     }

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use crate::manifest::{Manifest, Realm};
 use crate::package_id::PackageId;
 use crate::package_req::PackageReq;
-use crate::package_source::{PackageSourceId, PackageSourceImpl, PackageSourceMap};
+use crate::package_source::{PackageSourceId, PackageSourceMap, PackageSourceProvider};
 
 /// A completely resolved graph of packages returned by `resolve`.
 ///

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -9,13 +9,13 @@ use serde::Serialize;
 use crate::manifest::{Manifest, Realm};
 use crate::package_id::PackageId;
 use crate::package_req::PackageReq;
-use crate::package_source::{PackageSourceId, PackageSourceMap};
+use crate::package_source::{PackageSourceId, PackageSourceImpl, PackageSourceMap};
 
 /// A completely resolved graph of packages returned by `resolve`.
 ///
 /// State here is stored in multiple maps, all keyed by PackageId, to facilitate
 /// concurrent mutable access to unrelated information about different packages.
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, Default, Serialize, Clone)]
 pub struct Resolve {
     /// Set of all packages that have been chosen to be part of the package
     /// graph.
@@ -52,7 +52,7 @@ impl Resolve {
 /// Origin realm is the "most restrictive" realm the package can still be dependended
 /// upon. It is where the package gets placed during install.
 /// See [ origin_realm clarification ]. In the resolve function for more info.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ResolvePackageMetadata {
     pub realm: Realm,
     pub origin_realm: Realm,

--- a/wally-registry-backend/Cargo.toml
+++ b/wally-registry-backend/Cargo.toml
@@ -36,6 +36,7 @@ tokio = "1.1.1"
 url = { version = "2.2.1", features = ["serde"] }
 walkdir = "2.3.1"
 zip = "0.5.11"
+moka = "0.11.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/wally-registry-backend/src/storage/gcs.rs
+++ b/wally-registry-backend/src/storage/gcs.rs
@@ -5,19 +5,16 @@ use async_trait::async_trait;
 use cloud_storage_lite::client::{BucketClient, GcsBucketClient};
 use futures::TryStreamExt;
 use libwally::package_id::PackageId;
-use tokio::sync::Mutex;
 
 use super::{StorageBackend, StorageOutput};
 
 pub struct GcsStorage {
-    client: Mutex<GcsBucketClient>,
+    client: GcsBucketClient,
 }
 
 impl GcsStorage {
     pub fn new(client: GcsBucketClient) -> Self {
-        Self {
-            client: Mutex::new(client),
-        }
+        Self { client }
     }
 }
 
@@ -25,8 +22,7 @@ impl GcsStorage {
 impl StorageBackend for GcsStorage {
     async fn read(&self, key: &PackageId) -> anyhow::Result<StorageOutput> {
         let name = key.to_string();
-        let client = self.client.lock().await;
-        let stream = client.download_object(&name).await?;
+        let stream = self.client.download_object(&name).await?;
         let data = stream.map_ok(|chunk| chunk.to_vec()).try_concat().await?;
         Ok(Box::new(Cursor::new(data)))
     }
@@ -34,8 +30,7 @@ impl StorageBackend for GcsStorage {
     async fn write(&self, id: &PackageId, contents: &[u8]) -> anyhow::Result<()> {
         let contents = contents.to_vec();
         let name = id.to_string();
-        let client = self.client.lock().await;
-        client
+        self.client
             .create_object(
                 &name,
                 futures::stream::once(futures::future::ok::<_, Infallible>(contents)),

--- a/wally-registry-backend/src/storage/gcs.rs
+++ b/wally-registry-backend/src/storage/gcs.rs
@@ -5,25 +5,45 @@ use async_trait::async_trait;
 use cloud_storage_lite::client::{BucketClient, GcsBucketClient};
 use futures::TryStreamExt;
 use libwally::package_id::PackageId;
+use moka::sync::Cache;
 
 use super::{StorageBackend, StorageOutput};
 
 pub struct GcsStorage {
     client: GcsBucketClient,
+    cache: Option<Cache<PackageId, Vec<u8>>>,
 }
 
 impl GcsStorage {
-    pub fn new(client: GcsBucketClient) -> Self {
-        Self { client }
+    pub fn new(client: GcsBucketClient, cache_size: Option<u64>) -> Self {
+        if let Some(cache_size) = cache_size {
+            println!("Using storage moka caching (size: {cache_size})");
+        }
+
+        Self {
+            client,
+            cache: cache_size.map(Cache::new),
+        }
     }
 }
 
 #[async_trait]
 impl StorageBackend for GcsStorage {
     async fn read(&self, key: &PackageId) -> anyhow::Result<StorageOutput> {
+        if let Some(cache) = &self.cache {
+            if cache.contains_key(key) {
+                return Ok(Box::new(Cursor::new(cache.get(key).unwrap())));
+            }
+        }
+
         let name = key.to_string();
         let stream = self.client.download_object(&name).await?;
         let data = stream.map_ok(|chunk| chunk.to_vec()).try_concat().await?;
+
+        if let Some(cache) = &self.cache {
+            cache.insert(key.clone(), data.clone());
+        }
+
         Ok(Box::new(Cursor::new(data)))
     }
 

--- a/wally-registry-backend/src/storage/mod.rs
+++ b/wally-registry-backend/src/storage/mod.rs
@@ -25,6 +25,8 @@ pub enum StorageMode {
     },
     Gcs {
         bucket: String,
+        // Moka cache to keep the most popular packages in memory and accelerate response times
+        cache_size: Option<u64>,
     },
     #[cfg(feature = "s3-storage")]
     S3 {

--- a/wally-registry-backend/src/storage/mod.rs
+++ b/wally-registry-backend/src/storage/mod.rs
@@ -23,6 +23,7 @@ pub enum StorageMode {
     Local {
         path: Option<PathBuf>,
     },
+    #[serde(rename_all = "kebab-case")]
     Gcs {
         bucket: String,
         // Moka cache to keep the most popular packages in memory and accelerate response times


### PR DESCRIPTION
This PR adds support for downloading packages in parallel. It also:
- makes the install cli output more visually pleasing
- removes the mutex on the gcs client as it doesn't seem needed and causes concurrent requests to queue up and responded to serially
- adds moka caching to the download endpoint to reduce latency and accelerate download performance for popular packages