### PR TITLE
S3 backend storage improvements

### DIFF
--- a/wally-registry-backend/src/main.rs
+++ b/wally-registry-backend/src/main.rs
@@ -235,7 +235,9 @@ pub fn server(figment: Figment) -> rocket::Rocket<Build> {
             Box::new(configure_gcs(bucket, cache_size).unwrap())
         }
         #[cfg(feature = "s3-storage")]
-        StorageMode::S3 { bucket } => Box::new(configure_s3(bucket).unwrap()),
+        StorageMode::S3 { bucket, cache_size } => {
+            Box::new(configure_s3(bucket, cache_size).unwrap())
+        }
     };
 
     println!("Cloning package index repository...");
@@ -281,7 +283,7 @@ fn configure_gcs(bucket: String, cache_size: Option<u64>) -> anyhow::Result<GcsS
 }
 
 #[cfg(feature = "s3-storage")]
-fn configure_s3(bucket: String) -> anyhow::Result<S3Storage> {
+fn configure_s3(bucket: String, cache_size: Option<u64>) -> anyhow::Result<S3Storage> {
     use std::env;
 
     use rusoto_core::{credential::ChainProvider, request::HttpClient, Region};
@@ -297,7 +299,7 @@ fn configure_s3(bucket: String) -> anyhow::Result<S3Storage> {
         },
     );
 
-    Ok(S3Storage::new(client, bucket))
+    Ok(S3Storage::new(client, bucket, cache_size))
 }
 
 struct Cors;

--- a/wally-registry-backend/src/storage/mod.rs
+++ b/wally-registry-backend/src/storage/mod.rs
@@ -30,6 +30,8 @@ pub enum StorageMode {
         cache_size: Option<u64>,
     },
     #[cfg(feature = "s3-storage")]
+    #[cfg(feature = "s3-storage")]
+    #[serde(rename_all = "kebab-case")]
     S3 {
         bucket: String,
         cache_size: Option<u64>,

--- a/wally-registry-backend/src/storage/mod.rs
+++ b/wally-registry-backend/src/storage/mod.rs
@@ -32,6 +32,7 @@ pub enum StorageMode {
     #[cfg(feature = "s3-storage")]
     S3 {
         bucket: String,
+        cache_size: Option<u64>,
     },
 }
 

--- a/wally-registry-backend/src/storage/s3.rs
+++ b/wally-registry-backend/src/storage/s3.rs
@@ -3,22 +3,28 @@ use std::io::Cursor;
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use libwally::package_id::PackageId;
-use tokio::sync::Mutex;
+use moka::sync::Cache;
 
 use rusoto_s3::{GetObjectRequest, PutObjectRequest, S3Client, S3};
 
 use super::{StorageBackend, StorageOutput};
 
 pub struct S3Storage {
-    client: Mutex<S3Client>,
+    client: S3Client,
     bucket: String,
+    cache: Option<Cache<PackageId, Vec<u8>>>,
 }
 
 impl S3Storage {
-    pub fn new(client: S3Client, bucket: String) -> Self {
+    pub fn new(client: S3Client, bucket: String, cache_size: Option<u64>) -> Self {
+        if let Some(cache_size) = cache_size {
+            println!("Using storage moka caching (size: {cache_size})");
+        }
+
         Self {
-            client: Mutex::new(client),
+            client,
             bucket,
+            cache: cache_size.map(Cache::new),
         }
     }
 }
@@ -26,10 +32,16 @@ impl S3Storage {
 #[async_trait]
 impl StorageBackend for S3Storage {
     async fn read(&self, key: &PackageId) -> anyhow::Result<StorageOutput> {
-        let name = key.to_string();
-        let client = self.client.lock().await;
+        if let Some(cache) = &self.cache {
+            if cache.contains_key(key) {
+                return Ok(Box::new(Cursor::new(cache.get(key).unwrap())));
+            }
+        }
 
-        let result = client
+        let name = key.to_string();
+
+        let result = self
+            .client
             .get_object(GetObjectRequest {
                 bucket: self.bucket.to_owned(),
                 key: name.to_owned(),
@@ -39,15 +51,19 @@ impl StorageBackend for S3Storage {
 
         let stream = result.body.unwrap();
         let data = stream.map_ok(|chunk| chunk.to_vec()).try_concat().await?;
+
+        if let Some(cache) = &self.cache {
+            cache.insert(key.clone(), data.clone());
+        }
+
         Ok(Box::new(Cursor::new(data)))
     }
 
     async fn write(&self, id: &PackageId, contents: &[u8]) -> anyhow::Result<()> {
         let name = id.to_string();
-        let client = self.client.lock().await;
         let contents = contents.to_vec();
 
-        client
+        self.client
             .put_object(PutObjectRequest {
                 bucket: self.bucket.to_owned(),
                 key: name.to_owned(),


### PR DESCRIPTION
This PR brings the S3 storage backend up to parity with the changes to GCP storage in https://github.com/UpliftGames/wally/pull/133

- Removes the unnecessary mutex on the S3 client
- Adds moka caching with configurable cache size