### PR TITLE
Allow --token to be used in publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown 0.12.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.7",
+]
+
+[[package]]
 name = "devise"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,10 +1477,11 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2769,6 +2783,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3663,7 @@ dependencies = [
  "semver 0.11.0",
  "serde",
  "serde_json",
+ "serial_test",
  "structopt",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ globset = "0.4.8"
 ubyte = "0.10.3"
 indicatif = "0.17.4"
 tokio = "1.28.2"
+serial_test = "2.0.0"
 
 [dev-dependencies]
 insta = { version = "1.1.0" }

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ Parity with:
 * `cargo publish`
 * `npm update` (npm 7+, equivalent to `--depth 9999` in npm 6.x and older)
 
-### `wally publish`
+### `wally publish [--token <token>]`
 Publish the current package.
 
 Parity with:
 * `cargo publish`
 * `npm publish`
 
-### `wally login`
+### `wally login [--token <token>]`
 Log into an account to publish packages to a registry.
 
 You can also directly provide a token via `wally login --token "$WALLY_AUTH_TOKEN"`.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -37,6 +37,14 @@ impl AuthStore {
         Ok(auth)
     }
 
+    /// Simplifies the usecase of AuthStore::load()?.tokens.get(key)
+    /// If multiple tokens are needed you should use AuthStore::load()?.tokens instead
+    pub fn get_token(key: &str) -> anyhow::Result<Option<String>> {
+        // As this auth store will only live as long as this function we can just remove the value
+        // to give ownership to whatever needs it
+        Ok(Self::load()?.tokens.remove(key))
+    }
+
     pub fn set_token(key: &str, token: Option<&str>) -> anyhow::Result<()> {
         let path = file_path()?;
         let contents = Self::contents(&path)?;

--- a/src/commands/login.rs
+++ b/src/commands/login.rs
@@ -21,7 +21,7 @@ pub struct LoginSubcommand {
     /// Path to a project to decide how to login
     #[structopt(long = "project-path", default_value = ".")]
     pub project_path: PathBuf,
-    /// GitHub auth token to set directly
+    /// Auth token to set directly
     #[structopt(long = "token")]
     pub token: Option<String>,
     /// URL of the remote index to add an auth token for

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -61,6 +61,10 @@ pub struct GlobalOptions {
     /// Specify if the package index should be temporary (to prevent multiple use conflicts). Usable only by tests.
     #[structopt(skip)]
     pub use_temp_index: bool,
+
+    /// Specify if a specific auth token should be provided. Usable only by tests.
+    #[structopt(skip)]
+    pub check_token: Option<String>,
 }
 
 impl Default for GlobalOptions {
@@ -69,6 +73,7 @@ impl Default for GlobalOptions {
             verbosity: 0,
             test_registry: false,
             use_temp_index: false,
+            check_token: None,
         }
     }
 }

--- a/src/package_source/registry.rs
+++ b/src/package_source/registry.rs
@@ -41,13 +41,9 @@ impl Registry {
 
     fn auth_token(&self) -> anyhow::Result<Option<Arc<str>>> {
         self.auth_token
-            .get_or_try_init(|| {
-                let store = AuthStore::load()?;
-                let token = store.tokens.get(self.api_url()?.as_str());
-                match token {
-                    Some(token) => Ok(Some(Arc::from(token.as_str()))),
-                    None => Ok(None),
-                }
+            .get_or_try_init(|| match AuthStore::get_token(self.api_url()?.as_str())? {
+                Some(token) => Ok(Some(Arc::from(token.as_str()))),
+                None => Ok(None),
             })
             .map(|token| token.clone())
     }

--- a/tests/integration/publish.rs
+++ b/tests/integration/publish.rs
@@ -4,13 +4,15 @@ use fs_err::File;
 use libwally::{
     git_util, package_contents::PackageContents, Args, GlobalOptions, PublishSubcommand, Subcommand,
 };
+use serial_test::serial;
 use tempfile::tempdir;
 
 /// If the user tries to publish without providing any auth tokens
 /// then we should prompt them to provide a token via 'wally login'
 #[test]
+#[serial]
 fn check_prompts_auth() {
-    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects",));
+    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects"));
     let test_registry = Path::new(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/test-registries/primary-registry"
@@ -43,7 +45,7 @@ fn check_prompts_auth() {
 /// publish should edit the default.project.json during upload to match
 #[test]
 fn check_mismatched_names() {
-    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects",));
+    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects"));
     let contents = PackageContents::pack_from_path(&test_projects.join("mismatched-name")).unwrap();
 
     let unpacked_contents = tempdir().unwrap();
@@ -66,7 +68,7 @@ fn check_mismatched_names() {
 /// the package.
 #[test]
 fn check_private_field() {
-    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects",));
+    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects"));
 
     let args = Args {
         global: GlobalOptions {
@@ -91,8 +93,15 @@ fn check_private_field() {
 
 /// Ensure a token passed as an optional argument is correctly used in the request
 #[test]
+#[serial]
 fn check_token_arg() {
-    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects",));
+    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects"));
+    let test_registry = Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/test-registries/primary-registry"
+    ));
+
+    git_util::init_test_repo(&test_registry.join("index")).unwrap();
 
     let args = Args {
         global: GlobalOptions {

--- a/tests/integration/publish.rs
+++ b/tests/integration/publish.rs
@@ -26,6 +26,7 @@ fn check_prompts_auth() {
         },
         subcommand: Subcommand::Publish(PublishSubcommand {
             project_path: test_projects.join("minimal"),
+            token: None,
         }),
     };
 
@@ -75,6 +76,7 @@ fn check_private_field() {
         },
         subcommand: Subcommand::Publish(PublishSubcommand {
             project_path: test_projects.join("private-package"),
+            token: None,
         }),
     };
 
@@ -85,4 +87,26 @@ fn check_private_field() {
         "Expected error message that a private package cannot be published. Instead we got: {:#}",
         error
     )
+}
+
+/// Ensure a token passed as an optional argument is correctly used in the request
+#[test]
+fn check_token_arg() {
+    let test_projects = Path::new(concat!(env!("CARGO_MANIFEST_DIR"), "/test-projects",));
+
+    let args = Args {
+        global: GlobalOptions {
+            test_registry: true,
+            use_temp_index: true,
+            check_token: Some("token".to_owned()),
+            ..Default::default()
+        },
+        subcommand: Subcommand::Publish(PublishSubcommand {
+            project_path: test_projects.join("minimal"),
+            token: Some("token".to_owned()),
+        }),
+    };
+
+    args.run()
+        .expect("Publish did not use the provided token in the publish request");
 }


### PR DESCRIPTION
This PR adds the ability to use `wally publish --token "$AUTH_TOKEN"` instead of requiring a `wally login`. It also adds a helper function to make `AuthStore` more convenient and an integration test to ensure publish correctly passes the token to the publish request.