### PR TITLE
Update installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,36 @@ Wally has two pieces that work together: a command line tool named `wally` and a
 
 ## Installation
 
+### With Aftman (preferred)
+[Aftman][aftman] is the toolchain manager we reccomend. You can use it to install Wally:
+
+In your project (preferred)
+```bash
+aftman init
+aftman add UpliftGames/wally
+aftman install
+```
+
+Or install wally globally
+```bash
+aftman add --global UpliftGames/wally
+aftman install
+```
+
+[aftman]: https://github.com/LPGhatguy/aftman
+
+### Homebrew
+[Homebrew][homebrew] is also a convenient way to install wally! (only for MacOS/Linux)
+```bash
+brew install wally
+```
+
+[homebrew]: https://brew.sh/
+
 ### From GitHub
 Pre-built binaries are available for Windows, macOS, and Linux from the [GitHub Releases Page for Wally][releases].
 
 [releases]: https://github.com/UpliftGames/wally/releases
-
-### With Foreman
-[Foreman][foreman] is a toolchain manager developed for the Roblox community. You can use it to install Wally:
-
-``` toml
-wally = { source = "UpliftGames/wally", version = "0.3.2" }
-```
-
-[foreman]: https://github.com/Roblox/foreman
 
 ### From Source
 It's straightforward to compile Wally from source. Wally requires Rust 1.51.0 or newer.
@@ -63,7 +80,7 @@ Parity with:
 Update packages recursively. By default, will update all packages. If any package names are given (in the form `scope/name` or `scope/name@version-req`), just those packages will be updated instead.
 
 Parity with:
-* `cargo publish`
+* `cargo update`
 * `npm update` (npm 7+, equivalent to `--depth 9999` in npm 6.x and older)
 
 ### `wally publish`

--- a/wally-registry-frontend/src/pages/Install.mdx
+++ b/wally-registry-frontend/src/pages/Install.mdx
@@ -1,23 +1,37 @@
 # Installation
 
-## From GitHub
+## With Aftman (preferred)
+[Aftman][aftman] is the toolchain manager we reccomend. You can use it to install Wally:
 
+In your project (preferred)
+```bash
+aftman init
+aftman add UpliftGames/wally
+aftman install
+```
+
+Or install wally globally
+```bash
+aftman add --global UpliftGames/wally
+aftman install
+```
+
+[aftman]: https://github.com/LPGhatguy/aftman
+
+## Homebrew
+[Homebrew][homebrew] is also a convenient way to install wally! (only for MacOS/Linux)
+```bash
+brew install wally
+```
+
+[homebrew]: https://brew.sh/
+
+## From GitHub
 Pre-built binaries are available for Windows, macOS, and Linux from the [GitHub Releases Page for Wally][releases].
 
 [releases]: https://github.com/UpliftGames/wally/releases
 
-## With Foreman
-
-[Foreman][foreman] is a toolchain manager developed for the Roblox community. You can use it to install Wally:
-
-```toml
-wally = { source = "UpliftGames/wally", version = "0.3.2" }
-```
-
-[foreman]: https://github.com/Roblox/foreman
-
 ## From Source
-
 It's straightforward to compile Wally from source. Wally requires Rust 1.51.0 or newer.
 
 Clone the repository and use:


### PR DESCRIPTION
Foreman has been superseded by aftman, we should recommend aftman instead! Brew is also cool and convenient if you're into that and apparently has wally already!