### PR TITLE
Fix fatal error on package view where no versions contain '-'

### DIFF
--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -205,7 +205,7 @@ export default function Package() {
       ? packageData.versions.filter(
           (pack: WallyPackageMetadata) => !pack.package.version.includes("-")
         )
-      : packageData
+      : packageData.versions
 
     setPackageHistory(filteredPackageData)
 


### PR DESCRIPTION
closes #123 
(feels like a slightly silly mistake)