### PR TITLE
Fix downloaded file having no type extension

### DIFF
--- a/wally-registry-frontend/src/pages/Package.tsx
+++ b/wally-registry-frontend/src/pages/Package.tsx
@@ -393,7 +393,8 @@ export default function Package() {
                   "/" +
                   packageName +
                   "@" +
-                  packageMetadata.package.version
+                  packageMetadata.package.version +
+                  ".zip"
                 }
               >
                 <img


### PR DESCRIPTION
When you download a package, the file name ends with the version, so something like `package@1.0.0` would be read by your OS as a `.0` file type, which is obviously not what we wanted.

This fix is as simple as just adding `.zip` to the filename.