### PR TITLE
Dependency keys now have validation via `Alias` newtype.

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeSet;
-use std::convert::TryInto;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -9,6 +9,7 @@ use fs_err::File;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
+use crate::manifest::Alias;
 use crate::package_id;
 use crate::{
     manifest::Manifest, package_id::PackageId, package_name::PackageName, resolution::Resolve,
@@ -26,11 +27,8 @@ pub struct Lockfile {
 
 fn grab_dependencies(
     package_id: &PackageId,
-    dependencies: &BTreeMap<
-        package_id::PackageId,
-        BTreeMap<std::string::String, package_id::PackageId>,
-    >,
-) -> Vec<(String, PackageId)> {
+    dependencies: &BTreeMap<package_id::PackageId, BTreeMap<Alias, PackageId>>,
+) -> Vec<(Alias, PackageId)> {
     dependencies
         .get(package_id)
         .map(|dependencies| {
@@ -127,7 +125,7 @@ pub struct RegistryLockPackage {
     pub checksum: Option<String>,
 
     #[serde(default)]
-    pub dependencies: Vec<(String, PackageId)>,
+    pub dependencies: Vec<(Alias, PackageId)>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -6,7 +6,7 @@ use anyhow::format_err;
 use semver::Version;
 use serde::Serialize;
 
-use crate::manifest::{Manifest, Realm};
+use crate::manifest::{Alias, Manifest, Realm};
 use crate::package_id::PackageId;
 use crate::package_req::PackageReq;
 use crate::package_source::{PackageSourceId, PackageSourceMap, PackageSourceProvider};
@@ -26,17 +26,17 @@ pub struct Resolve {
     pub metadata: BTreeMap<PackageId, ResolvePackageMetadata>,
 
     /// Graph of all dependencies originating from the "shared" dependency realm.
-    pub shared_dependencies: BTreeMap<PackageId, BTreeMap<String, PackageId>>,
+    pub shared_dependencies: BTreeMap<PackageId, BTreeMap<Alias, PackageId>>,
 
     /// Graph of all dependencies originating from the "server" dependency realm.
-    pub server_dependencies: BTreeMap<PackageId, BTreeMap<String, PackageId>>,
+    pub server_dependencies: BTreeMap<PackageId, BTreeMap<Alias, PackageId>>,
 
     /// Graph of all dependencies originating from the "dev" dependency realm.
-    pub dev_dependencies: BTreeMap<PackageId, BTreeMap<String, PackageId>>,
+    pub dev_dependencies: BTreeMap<PackageId, BTreeMap<Alias, PackageId>>,
 }
 
 impl Resolve {
-    fn activate(&mut self, source: PackageId, dep_name: String, dep_realm: Realm, dep: PackageId) {
+    fn activate(&mut self, source: PackageId, dep_name: Alias, dep_realm: Realm, dep: PackageId) {
         self.activated.insert(dep.clone());
 
         let dependencies = match dep_realm {
@@ -314,7 +314,7 @@ pub struct DependencyRequest {
     request_source: PackageId,
     request_realm: Realm,
     origin_realm: Realm,
-    package_alias: String,
+    package_alias: Alias,
     package_req: PackageReq,
 }
 

--- a/src/test_package.rs
+++ b/src/test_package.rs
@@ -59,23 +59,27 @@ impl PackageBuilder {
 
     pub fn with_dep<A, R>(mut self, alias: A, package_req: R) -> Self
     where
-        A: Into<String>,
+        A: AsRef<str>,
         R: AsRef<str>,
     {
         let req: PackageReq = package_req.as_ref().parse().expect("invalid PackageReq");
 
-        self.manifest.dependencies.insert(alias.into(), req);
+        self.manifest
+            .dependencies
+            .insert(alias.as_ref().parse().expect("invalid alias"), req);
         self
     }
 
     pub fn with_server_dep<A, R>(mut self, alias: A, package_req: R) -> Self
     where
-        A: Into<String>,
+        A: AsRef<str>,
         R: AsRef<str>,
     {
         let req: PackageReq = package_req.as_ref().parse().expect("invalid PackageReq");
 
-        self.manifest.server_dependencies.insert(alias.into(), req);
+        self.manifest
+            .server_dependencies
+            .insert(alias.as_ref().parse().expect("invalid alias"), req);
         self
     }
 


### PR DESCRIPTION
**Relevant Changes**
- World Peace has been achieved.
  -  Restrictions on Alias: must be a valid Lua identifier (alphanumeric ASCII + underscores + no leading digit) and not be harmful to the file system.
- The Resolve graph from resolution now uses Alias to link dependencies together instead of strings.
  * This is a breaking change to the public API.
- The lock file now uses Alias to name dependencies instead of strings.
  * This means old lock files will now be validated when they weren't before. There's an infinitesimal chance that someone will be uppity about this.
- test_packages got alias adoption, it's happy, it's internal.
- All tests are passing, yay!
