### PR TITLE
Add cargo features build arg to Docker build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 
 services:
   backend:
+    image: 386138156553.dkr.ecr.us-west-2.amazonaws.com/wally-backend:latest
     build:
       context: .
       dockerfile: wally-registry-backend/Dockerfile
@@ -11,7 +12,7 @@ services:
       - "8000:8000"
 
   frontend:
-    build: wally-registry-frontend
+    image: 386138156553.dkr.ecr.us-west-2.amazonaws.com/wally-frontend:latest
     ports:
       - "8001:8000"
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: .
       dockerfile: wally-registry-backend/Dockerfile
+      args:
+        - WALLY_BACKEND_BUILD_FEATURES=${WALLY_BACKEND_BUILD_FEATURES}
     ports:
       - "8000:8000"
 

--- a/wally-registry-backend/Dockerfile
+++ b/wally-registry-backend/Dockerfile
@@ -16,13 +16,20 @@ COPY wally-registry-backend/Cargo.toml /usr/app/wally-registry-backend/
 COPY Cargo.toml Cargo.lock /usr/app/
 COPY src/ /usr/app/src/
 
-RUN cargo build --package wally-registry-backend --release
+ARG WALLY_BACKEND_BUILD_FEATURES
+RUN if [ -n "$WALLY_BACKEND_BUILD_FEATURES" ]; then \
+        cargoFeatures="--features $WALLY_BACKEND_BUILD_FEATURES"; \
+    fi && \
+    cargo build --package wally-registry-backend --release $cargoFeatures
 
 # Copy actual application source in and force a modified timestamp so that
 # Cargo will rebuild.
 COPY ./wally-registry-backend ./wally-registry-backend/
 RUN touch wally-registry-backend/src/main.rs
-RUN cargo build --package wally-registry-backend --release
+RUN if [ -n "$WALLY_BACKEND_BUILD_FEATURES" ]; then \
+        cargoFeatures="--features $WALLY_BACKEND_BUILD_FEATURES"; \
+    fi && \
+    cargo build --package wally-registry-backend --release $cargoFeatures
 
 FROM debian:buster-slim
 


### PR DESCRIPTION
## Proposed changes

This pull adds the ability to pass `--features` options to `cargo build` via the `WALLY_BACKEND_BUILD_FEATURES` environment variable upon running Docker compose. Namely, this is helpful for enabling the s3-storage feature.