### PR TITLE
Adds a fun install alias

### DIFF
--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -17,6 +17,7 @@ use super::GlobalOptions;
 
 /// Install all of the dependencies of this project.
 #[derive(Debug, StructOpt)]
+#[structopt(alias = "instally")]
 pub struct InstallSubcommand {
     /// Path to the project to install dependencies for.
     #[structopt(long = "project-path", default_value = ".")]


### PR DESCRIPTION
A very simple PR that adds a fun install alias. `wally instally`

My coworkers and I would always make the joke when installing and thought it may be fun for the Wally community.