### PR TITLE
BLD: Cargo.toml:  tokio {, features = ["rt-multi-thread"] }

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ zip = "0.5.11"
 globset = "0.4.8"
 ubyte = "0.10.3"
 indicatif = "0.17.4"
-tokio = "1.28.2"
+tokio = { version = "1.28.2",  features = ["rt-multi-thread"] }
 serial_test = "2.0.0"
 time = "=0.3.35"
 


### PR DESCRIPTION
This did solve for this error message on `cargo install wally` fwics because `cargo install --git https://github.com/westurner --branch patch-1 wally` worked

```
error[E0599]: no function or associated item named `new_multi_thread` found for struct `tokio::runtime::Builder` in the current scope
```

IDK if there's a reason to not have this for every build?

- Wally compiled with `rt-multi-thread` in a `fedora-toolbox:41` container with `dnf install cargo` (that I'm setting up for use with vscode `/.devcontainer/devcontainer.json`)