### PR TITLE
Add GithubOAuthPrivate registry backend AuthMode

### DIFF
--- a/wally-registry-backend/src/auth.rs
+++ b/wally-registry-backend/src/auth.rs
@@ -274,6 +274,7 @@ async fn verify_github<AccessType: GithubAccessor>(
 pub enum ReadAccess {
     Public,
     ApiKey,
+    #[allow(dead_code)]
     Github(GithubInfo),
 }
 


### PR DESCRIPTION
This PR adds a new AuthMode for the registry backend, GithubOAuthPrivate. It is based on the GithubOAuth mode except that it requires any read or write access API callers to have at least view access on the index repository. This allows private registries to maintain full isolation without having to resort to API keys. It also enforces GitHub based ownership of scopes as GithubOAuth did.

This addition is not a breaking change: the GitHub access token provided to the backend does not need updated in order to check for index repository view access. The minimum required capabilities (content, metadata) of a fine-grained PAT allow checking the repository contributor permissions API.